### PR TITLE
Map options

### DIFF
--- a/gamedata/lua/lua/ui/dialogs/mapselect.lua
+++ b/gamedata/lua/lua/ui/dialogs/mapselect.lua
@@ -660,17 +660,13 @@ function SetupOptionsPanel(parent, singlePlayer, curOptions)
 
                 -- combo logic
                 line.combo:Hide()
-            end
-
-            if element.type == 'spacer' then
+            elseif element.type == 'spacer' then
                 -- header logic
                 line.text:SetText('')
 
                 -- combo logic
                 line.combo:Hide()
-            end
-
-            if element.type == 'option' then 
+            elseif element.type == 'option' then 
                 -- header logic
                 line.text:SetText(LOC(element.text))
                 line.text:SetFont(UIUtil.bodyFont, 14)

--- a/gamedata/lua/lua/ui/dialogs/mapselect.lua
+++ b/gamedata/lua/lua/ui/dialogs/mapselect.lua
@@ -659,10 +659,15 @@ function SetupOptionsPanel(parent, singlePlayer, curOptions)
                 line.combo:Hide()
                 LayoutHelpers.AtLeftTopIn(line.text, line, 0, 20)
                 LayoutHelpers.AtHorizontalCenterIn(line.text, line)
-            elseif data.type == 'spacer' then
+            end
+
+            if data.type == 'spacer' then
                 line.text:SetText('')
                 line.combo:Hide()
-            else
+            end
+
+            if data.type == 'option' then 
+
                 line.text:SetText(LOC(data.text))
                 line.text:SetFont(UIUtil.bodyFont, 14)
                 line.text:SetColor(UIUtil.fontColor)
@@ -674,6 +679,8 @@ function SetupOptionsPanel(parent, singlePlayer, curOptions)
                 line.combo.keyMap = {}
                 local tooltipTable = {}
                 for index, val in data.data.values do
+
+
                     itemArray[index] = val.text
                     line.combo.keyMap[val.key] = index
                     tooltipTable[index] = 'lob_'..data.data.key..'_'..val.key

--- a/gamedata/lua/lua/ui/lobby/lobby.lua
+++ b/gamedata/lua/lua/ui/lobby/lobby.lua
@@ -1247,10 +1247,10 @@ local function AssignDefaultMapOptions(gameInfo)
         end
     end
     
-    scenarioInfo = MapUtil.LoadScenario(gameInfo.GameOptions.ScenarioFile)
+    local scenarioInfo = MapUtil.LoadScenario(gameInfo.GameOptions.ScenarioFile)
     if scenarioInfo.options then 
         for _, option in scenarioInfo.options do 
-            if not gameInfo.GameOptions[option.key] then 
+            if not gameInfo.GameOptions[option.key] then
 
                 -- ensure the default is sane
                 CheckAndCorrectDefaultOption(option)
@@ -1626,9 +1626,6 @@ local function TryLaunch(skipNoObserversCheck, skipSandboxCheck, skipTimeLimitCh
         AssignRandomFactions(gameInfo)
         AssignRandomStartSpots(gameInfo)
         AssignAINames(gameInfo)
-
-        -- assign (default) map options if applicable
-        AssignDefaultMapOptions(gameInfo)
         
 		LOG("HERE WE GO "..repr( { Options = gameInfo.GameOptions, HostedBy = localPlayerName, PlayerCount = GetPlayerCount(), GameName = gameName }) )
     
@@ -4637,6 +4634,9 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
         CreateUI(LobbyComm.maxPlayerSlots, useSteam)
 		
 		EnhancedLobby.BroadcastAIInfo(lobbyComm:IsHost())
+
+        -- Assign (default) map options if applicable
+        AssignDefaultMapOptions(gameInfo)
 
         UpdateGame()
 

--- a/gamedata/lua/lua/ui/lobby/lobby.lua
+++ b/gamedata/lua/lua/ui/lobby/lobby.lua
@@ -1201,6 +1201,85 @@ local function AssignRandomFactions(gameInfo)
 	
 end
 
+local function AssignDefaultMapOptions(gameInfo)
+
+    local function CheckAndCorrectDefaultOption(option)
+
+        -- assume the option is valid
+        local valid = true
+
+        -- check if it is a number
+        valid = valid and type(option.default) == "number" 
+
+        -- check if it is an integral number
+        valid = valid and math.floor(option.default) == option.default 
+
+        -- check if it is an valid index of the values table
+        valid = valid and option.values[option.default]
+
+        if not valid then 
+
+            -- tell us (the developer) about it
+            WARN("Option " .. option.label .. " has an invalid default (" .. option.default .. "). The default value is the table index, not the actual value.")
+
+            -- try and find the actual index so that the game doesn't crash
+            for k, t in option.values do 
+                -- key-based
+                if t.key == option.default then 
+                    valid = true 
+                    option.default = k 
+                    break 
+                end
+
+                -- value-based 
+                if t == option.default then 
+                    valid = true 
+                    option.default = k
+                    break 
+                end
+            end
+
+            -- we couldn't find the actual index: resetting to 1.
+            if not valid then 
+                option.default = 1 
+                WARN("Option " .. option.label .. " could not retrieve the correct index-based default value. Defaulting to index 1.")
+            end
+        end
+    end
+    
+    scenarioInfo = MapUtil.LoadScenario(gameInfo.GameOptions.ScenarioFile)
+    if scenarioInfo.options then 
+        for _, option in scenarioInfo.options do 
+            if not gameInfo.GameOptions[option.key] then 
+
+                -- ensure the default is sane
+                CheckAndCorrectDefaultOption(option)
+
+                -- When the value data of the option is formatted as:
+                -- values = {
+                --     { text = "Easy", help = "We'll have sufficient time to start building up our defense strategy.", key = 1, },		
+                --     { text = "Normal", help = "There's sufficient time - but we'll need to hurry up.", key = 2, },	
+                --     { text = "Heroic", help = "There's little time - no space for errors.", key = 3, },	
+                --     { text = "Legendary", help = "We're dropped in the middle of it - we knew it was a bad mission when we signed up for it.", key = 4, },
+                -- },	
+                local keyVersion = option.values[option.default].key
+
+                -- When the value data of the option is formatted as:
+                -- values = {
+                --     '1','2','3','4','5','6','7','8','9','10','11','12','13','14','15','16','17','18','19','20'
+                -- }
+                local valueVersion = option.values[option.default]
+
+                -- Expect a key version, fall back on a value version
+                gameInfo.GameOptions[option.key] = keyVersion or valueVersion
+
+                -- Can be removed once this code leaves the develop branch
+                LOG("Loading default map option: " .. tostring (option.key) .. " = " .. tostring (gameInfo.GameOptions[option.key]))
+            end
+        end
+    end
+end
+
 local function AssignRandomStartSpots(gameInfo)
 
     if gameInfo.GameOptions['TeamSpawn'] == 'random' then
@@ -1547,7 +1626,10 @@ local function TryLaunch(skipNoObserversCheck, skipSandboxCheck, skipTimeLimitCh
         AssignRandomFactions(gameInfo)
         AssignRandomStartSpots(gameInfo)
         AssignAINames(gameInfo)
-		
+
+        -- assign (default) map options if applicable
+        AssignDefaultMapOptions(gameInfo)
+        
 		LOG("HERE WE GO "..repr( { Options = gameInfo.GameOptions, HostedBy = localPlayerName, PlayerCount = GetPlayerCount(), GameName = gameName }) )
     
         -- Tell everyone else to launch and then launch ourselves.

--- a/gamedata/lua/lua/ui/lobby/lobby.lua
+++ b/gamedata/lua/lua/ui/lobby/lobby.lua
@@ -3816,11 +3816,19 @@ function RefreshOptionDisplayData(scenarioInfo)
         if not option and scenarioInfo.options then
             for index, optData in scenarioInfo.options do
                 if i == optData.key then
-                    option = {text = optData.label, tooltip = optData.pref}
+
+                    -- map options are not considered to be official options
+
+                    -- if data.tooltip then
+                    --     Tooltip.AddControlTooltip(line.value.bg, data.tooltip)
+                    --     Tooltip.AddControlTooltip(line.value.bg2, data.valueTooltip)
+                    -- end
+
+                    option = { text = optData.label, tooltip = { text = optData.label, body = optData.help } }
                     for _, val in optData.values do
                         if val.key == v then
                             option.value = val.text
-                            option.valueTooltip = 'lob_'..optData.key..'_'..val.key
+                            option.valueTooltip = { text = val.text, body = val.help }
                             break
                         end
                     end


### PR DESCRIPTION
Includes various fixes for map options:
 - The default value of an option is chosen if it is not found in previous preferences / game options list-> map options initially show their default value as they are not recorded in the preferences list.
 - The default value of a map option is loaded into the map if it wasn't set manually.
 - All options have a tooltip that is either loaded in from the string database or from the option table itself. If the option does not have a preference value set (set to '', not nil / removed!) then the tooltips in the option table is used.
 - Options have tooltips both in the map select dialog and in the lobby.

Known issues:
 - The 'default' value of an option is often not interpreted correctly in the FAF community. In turn, it is often set to the _value_ instead of the _table index_. There is a safe guard for this when launching the game, but that safeguard is not present when an option is transformed into a combo box in the map select dialog. If a vaulty default value is presented the map select dialog shows undefined behavior.

The vault in LOUD is a white-list system but it can still go wrong on accident.

Potential fixes:
 - We apply the same safe guard to the transformation to the combo box. This is a for loop and not part of the sim, but it is not efficient either.
 - We load in the map options once and cache them. Correct the cache once / throw warnings and remove invalid options. If the options are requested then the cache is returned. If the map is changed the cache is reset and re-populated. This requires a bit of re-work however but is the most efficient solution of the two.