### PR TITLE
Wreckage lifetime when spawned

### DIFF
--- a/gamedata/lua/lua/sim/ScenarioUtilities.lua
+++ b/gamedata/lua/lua/sim/ScenarioUtilities.lua
@@ -798,7 +798,7 @@ function CreateArmyGroup(strArmy,strGroup,wreckage, balance)
     end
     if wreckage then
         for num, unit in tblResult do
-            unit:CreateWreckageProp()
+            unit:CreateWreckageProp(0, 1800)
             unit:Destroy()
         end
         return


### PR DESCRIPTION
Applies the same life time to a unit group spawned as wreckages as any group called 'WRECKAGE' would have.