### PR TITLE
Supremacy VC Revisited

### DIFF
--- a/gamedata/BlackOps/mods/BlackOpsUnleashed/units/BSB2402/BSB2402_unit.bp
+++ b/gamedata/BlackOps/mods/BlackOpsUnleashed/units/BSB2402/BSB2402_unit.bp
@@ -32,6 +32,7 @@ UnitBlueprint {
         'RECLAIMABLE',
         'SHOWQUEUE',
         'SORTCONSTRUCTION',
+        'NONSUPREMACY',
     },
 	
     Defense = {

--- a/gamedata/BrewLAN_LOUD/mods/BrewLAN_LOUD/units/SEB3303/SEB3303_unit.bp
+++ b/gamedata/BrewLAN_LOUD/mods/BrewLAN_LOUD/units/SEB3303/SEB3303_unit.bp
@@ -28,6 +28,7 @@ UnitBlueprint {
         'RALLYPOINT',
         'SHOWQUEUE',
         --'GATE',
+        'NONSUPREMACY',
     },
 	
     Defense = {

--- a/gamedata/LOUD_Units/mods/LOUD Unit Additions/units/UAB0305/UAB0305_unit.bp
+++ b/gamedata/LOUD_Units/mods/LOUD Unit Additions/units/UAB0305/UAB0305_unit.bp
@@ -52,6 +52,7 @@ UnitBlueprint {
         'VISIBLETORECON',
         'RECLAIMABLE',
         'SORTINTEL',
+        'NONSUPREMACY',
     },
 	
     CollisionOffsetZ = 0,

--- a/gamedata/LOUD_Units/mods/LOUD Unit Additions/units/UEB0305/UEB0305_unit.bp
+++ b/gamedata/LOUD_Units/mods/LOUD Unit Additions/units/UEB0305/UEB0305_unit.bp
@@ -49,6 +49,7 @@ UnitBlueprint {
         'VISIBLETORECON',
         'RECLAIMABLE',
         'SORTINTEL',
+        'NONSUPREMACY',
     },
 	
     CollisionOffsetY = -0.25,

--- a/gamedata/LOUD_Units/mods/LOUD Unit Additions/units/URB0305/URB0305_unit.bp
+++ b/gamedata/LOUD_Units/mods/LOUD Unit Additions/units/URB0305/URB0305_unit.bp
@@ -50,6 +50,7 @@ UnitBlueprint {
         'VISIBLETORECON',
         'RECLAIMABLE',
         'SORTINTEL',
+        'NONSUPREMACY',
     },
 	
     Defense = {

--- a/gamedata/LOUD_Units/mods/LOUD Unit Additions/units/XSB0305/XSB0305_unit.bp
+++ b/gamedata/LOUD_Units/mods/LOUD Unit Additions/units/XSB0305/XSB0305_unit.bp
@@ -42,6 +42,7 @@ UnitBlueprint {
         'VISIBLETORECON',
         'RECLAIMABLE',
         'SORTINTEL',
+        'NONSUPREMACY',
     },
 	
     CollisionOffsetZ = 0,

--- a/gamedata/TotalMayhem/mods/TotalMayhem/units/BRMT3AVA/BRMT3AVA_unit.bp
+++ b/gamedata/TotalMayhem/mods/TotalMayhem/units/BRMT3AVA/BRMT3AVA_unit.bp
@@ -74,6 +74,7 @@ UnitBlueprint {
         'OVERLAYDIRECTFIRE',
         'OVERLAYDEFENSE',
         'OVERLAYOMNI',
+        'SUPREMACY',
     },
 	
 	CollisionOffsetY = 1.6,

--- a/gamedata/lua/lua/victory.lua
+++ b/gamedata/lua/lua/victory.lua
@@ -14,7 +14,7 @@ function CheckVictory(ScenarioInfo)
 		
     elseif ScenarioInfo.Options.Victory == 'domination' then
         -- Supremacy - A player is defeated when all engineers, factories and any unit that can build an engineer are destroyed.
-        categoryCheck = categories.ENGINEER + categories.FACTORY --+ categories.BRMT3AVA   --+ categories.SSL0403) - categories.CARRIER - categories.RESEARCHCENTRE     -- categories.UAB0305 - categories.URB0305 - categories.XSB0305 - categories.UEB0305 - categories.SRB5310 - categories.SEB5310 - categories.BSB2402 - categories.SEB3303
+        categoryCheck = categories.ENGINEER + categories.FACTORY + categories.MOBILEBUILDERONLY + categories.SUPREMACY - categories.CARRIER - categories.HEAVYWALLGATE - categories.RESEARCHCENTRE - categories.NONSUPREMACY
 	
     elseif ScenarioInfo.Options.Victory == 'eradication' then
         -- Annihilation - A player is defeated when all structures (except walls) and all units are destroyed.

--- a/gamedata/units/units/UEB5103/UEB5103_unit.bp
+++ b/gamedata/units/units/UEB5103/UEB5103_unit.bp
@@ -6,6 +6,9 @@ UnitBlueprint {
         'SIZE4',
         'TELEPORTBEACON',
         'VISIBLETORECON',
+        'HEAVYWALLGATE',
+        'RESEARCHCENTRE',
+        'NONSUPREMACY',
     },
     CollisionOffsetY = -0.25,
     Defense = {

--- a/gamedata/units/units/URB5103/URB5103_unit.bp
+++ b/gamedata/units/units/URB5103/URB5103_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint {
         'TELEPORTBEACON',
         'VISIBLETORECON',
 		'INSIGNIFICANTUNIT',
+        'MOBILEBUILDERONLY',
     },
     CollisionOffsetY = -0.25,
     Defense = {

--- a/gamedata/units/units/XRL0403/XRL0403_unit.bp
+++ b/gamedata/units/units/XRL0403/XRL0403_unit.bp
@@ -78,6 +78,7 @@ UnitBlueprint {
         'SHOWQUEUE',
 		'OVERLAYRADAR',
         'OVERLAYSONAR',
+        'SUPREMACY',
     },
     
     CollisionOffsetY = 2,


### PR DESCRIPTION
- Remove unitIDs as categories and replace with actual Categories to allow for correct intended functioning of Supremacy VC.
- Add categories as needed in multiple unit BPs to allow for correct intended functioning of Supremacy VC.