### PR TITLE
UNITS - Cybran UEF SACU Energy Prod Descrip Fix

### DIFF
--- a/gamedata/units/units/UEL0301/UEL0301_unit.bp
+++ b/gamedata/units/units/UEL0301/UEL0301_unit.bp
@@ -123,8 +123,6 @@ UnitBlueprint {
             'BUILTBYTIER3ENGINEER UEF',
         },
 		
-        MaintenanceConsumptionPerSecondEnergy = 0,
-		
         NaturalProducer = true,
 		
         ProductionPerSecondEnergy = 200,

--- a/gamedata/units/units/URL0301/URL0301_unit.bp
+++ b/gamedata/units/units/URL0301/URL0301_unit.bp
@@ -122,9 +122,7 @@ UnitBlueprint {
             'BUILTBYTIER3ENGINEER CYBRAN',
         },
 		
-        MaintenanceConsumptionPerSecondEnergy = 0,
-		
-		MaxBuildDistance = 8,
+        MaxBuildDistance = 8,
 		
         NaturalProducer = true,
 		


### PR DESCRIPTION
- Removed line "MaintenanceConsumptionPerSecondEnergy = 0," from Cybran SACU (url0301) and UEF SACU (uel0301) bp files to correct energy production shown in Quantum Gatway build menu.