### PR TITLE
Aircraft AutoInitiateAttack Update

### DIFF
--- a/gamedata/BrewLAN_LOUD/mods/BrewLAN_LOUD/units/SRA0313/SRA0313_unit.bp
+++ b/gamedata/BrewLAN_LOUD/mods/BrewLAN_LOUD/units/SRA0313/SRA0313_unit.bp
@@ -405,7 +405,7 @@ UnitBlueprint {
         },
         {
             Audio = {Fire = Sound {Bank = 'URLWeapon', Cue = 'URB2301_Cannon_Sgl', LodCutoff = 'Weapon_LodCutoff'}},
-            AutoInitiateAttackCommand = true,
+            AutoInitiateAttackCommand = false,
             BallisticArc = 'RULEUBA_None',
 			
             BeamCollisionDelay = 0,


### PR DESCRIPTION
- Change AutoInitiateAttackCommand to false for the BrewLAN Cybran Twilight Patron T3 Penetration Fighter (sra0313)