### PR TITLE
Initial cleanup for lua_utils compatibility

### DIFF
--- a/gamedata/lua/lua/PhxLib.lua
+++ b/gamedata/lua/lua/PhxLib.lua
@@ -508,9 +508,11 @@ PhxLib.PhxWeapDPS = function(weapon)
 
         -- This is a rare weapon catch that skips OnFire() and
         --   EconDrain entirely, its kinda scary.
-        if (weapon.RackSalvoFiresAfterCharge and weapon.RackSalvoReloadTime>0 and weapon.RackSalvoChargeTime>0 ) then
-            Ttime = muzzleTime + RackTime
-            Warn = Warn .. "RackSalvoFiresAfterCharge_ComboWarn,"
+        if (weapon.RackSalvoFiresAfterCharge and weapon.RackSalvoReloadTime and weapon.RackSalvoChargeTime ) then
+            if (weapon.RackSalvoFiresAfterCharge and weapon.RackSalvoReloadTime>0 and weapon.RackSalvoChargeTime>0 ) then
+                Ttime = muzzleTime + RackTime
+                Warn = Warn .. "RackSalvoFiresAfterCharge_ComboWarn,"
+            end
         end
 
         -- Units Affected: 
@@ -643,13 +645,28 @@ PhxLib.calcUnitDPS = function(curShortID,curBP)
         
         for curWepID,curWep in ipairs(curBP.Weapon) do
         
-            local weapDPS
-            
+            local weapDPS = {}
+            weapDPS.Range = 0
+            weapDPS.WeaponName = 'none'
+            weapDPS.Damage = 0 
+            weapDPS.Ttime = 1
+            weapDPS.srfDPS = 0
+            weapDPS.subDPS = 0
+            weapDPS.airDPS = 0
+            weapDPS.DPS = 0
+            weapDPS.Warn = ''
+            weapDPS.threatRange = 1
+            weapDPS.threatSurf = 1
+            unitDPS.Threat.srfTotal = 0
+            unitDPS.Threat.subTotal = 0
+            unitDPS.Threat.airTotal = 0
+    
+
             if curWep.RateOfFire then
                 weapDPS = PhxLib.PhxWeapDPS(curWep)
             else
                 -- this line short circuits any unit
-                if curWep.Label != "DeathWeapon" and curWep.Label != "DeathImpact" and curWep.Label != "CollossusDeath" and curWep.Label != "Suicide" then
+                if (curWep.Label ~= "DeathWeapon" and curWep.Label ~= "DeathImpact" and curWep.Label ~= "CollossusDeath" and curWep.Label ~= "Suicide") then
                     LOG("**"..curShortID.."/"..PhxLib.cleanUnitName(curBP)..repr(curWep).." has NO RateOfFire" )
                 end
             
@@ -657,7 +674,10 @@ PhxLib.calcUnitDPS = function(curShortID,curBP)
                     LOG("**"..curShortID.." weapon "..repr(curWep.Label).." skipped")
                 end
                 
-                continue -- skip this weapon  -- return 0 was aborting this unit
+                --continue -- skip this weapon  -- return 0 was aborting this unit 
+                -- DJO: I removed this for command-line lua compatibilty, moved "nul" weapon definition to local weapDPS = {} statements above.
+                --      This should allow for valid skipping of weapons without the use of continue or return.
+
             end
             
             if debug then
@@ -727,18 +747,19 @@ PhxLib.calcUnitDPS = function(curShortID,curBP)
         unitDPS.airDPS = 166
         unitDPS.totDPS = 166
         unitDPS.maxRange = 25
+
         --unitDPS.Warn = '' -- Leave warnings alone
     end -- oddball catch
     
-    if unitDPS.Threat.srfDam > 0 then
+    if unitDPS.Threat.srfDam >= 0 then
         unitDPS.Threat.srfTotal = unitDPS.Threat.srfDam + unitDPS.Threat.HP + unitDPS.Threat.Speed + unitDPS.Threat.Range
     end
     
-    if unitDPS.Threat.subDam > 0 then
+    if unitDPS.Threat.subDam >= 0 then
         unitDPS.Threat.subTotal =  unitDPS.Threat.subDam + unitDPS.Threat.HP
     end
     
-    if unitDPS.Threat.airDam > 0 then
+    if unitDPS.Threat.airDam >= 0 then
         unitDPS.Threat.airTotal = unitDPS.Threat.airDam + unitDPS.Threat.HP
     end
     

--- a/lua_utils/bluePrintExtractor/threatParser_v007.lua
+++ b/lua_utils/bluePrintExtractor/threatParser_v007.lua
@@ -1,0 +1,216 @@
+-- This file is the initial pass for debugging PhxWeapDPS
+-- all BP files are scanned, DPS and threat is calcualted on a per weapon basis
+-- summed up per unit and output to outputFileName is spreadsheet friendly format
+local outputFileName = "LOUD_UnitDB_v007.csv"
+
+local dirtree = require('dirtree')
+
+dofile('../../gamedata/lua/lua/PhxLib.lua')
+local cleanUnitName = PhxLib.cleanUnitName
+local getTechLevel = PhxLib.getTechLevel
+local getVision = PhxLib.getVision
+local getWaterVision = PhxLib.getWaterVision
+local calcUnitDPS = PhxLib.calcUnitDPS
+
+local allBlueprints = {}
+local curBlueprint = {}
+local allShortIDs = {}
+local allFullDirs = {}
+local countBPs = 0
+local countFiles = 0
+
+function LOG(string)
+    print(string)
+end
+
+function repr(var)
+    return ""
+end
+
+function UnitBlueprint(bp)
+    -- Helper function that replaces the SCFA function UnitBlueprint() and
+    --   instead concatinates all BPs into "allBlueprints"
+    -- Required Globals (bad practice I know, but kludge.)
+    --    curBlueprint
+    --    allBlueprints
+    --    countBPs
+    -- TODO: check if BP already exists and merge BP if possible.  Is this even appropriate for unit upgrades?
+    countBPs = countBPs + 1
+    if(not bp.Merge) then 
+        table.insert(allBlueprints, bp)
+    end
+    curBlueprint = bp
+end
+
+function Sound(list)
+    -- Dummy function that replaces the SCFA function Sound()
+    -- This is required to execute .bp files in commandline LUA interpretter
+    return list
+end
+
+-- Initial loop that finds and runs each BP file in the path given
+-- This will generate the following:
+--   allBlueprints - a single table with all BPs in it.
+--   allShortIDs - a table of UnitIDSs for all BPs (Stripped from file names)
+--   allFullDirs - a table of full directory path to each BP
+local baseFolder = "../../gamedata"
+print("Reading blueprints...")
+print("Scanning all folders in " .. baseFolder)
+for filename, attr in dirtree("../../gamedata/") do
+    if string.find(filename, '.*/units/.*_unit%.bp') then
+        -- filename = "./modDir/units/UAL0402_unit.bp"
+
+        --print("Found Matching File:", filename)
+        UnitBaseName = string.match(filename, '[%a%d]*_unit%.bp$')
+        -- UnitBaseName = "UAL0402_unit.bp"
+
+        local strStrt = 1
+        local strStop = string.find(UnitBaseName,"[_%.]") - 1 --Find first _ or .
+        UnitBaseName = string.sub(UnitBaseName,strStrt,strStop)
+        -- UnitBaseName = "UAL0402"
+
+        --print(UnitBaseName)
+        countFiles = countFiles + 1
+        dofile(filename)
+        if(not curBlueprint.Merge) then 
+            table.insert(allShortIDs, UnitBaseName)
+            table.insert(allFullDirs, filename)          
+            --print("Processing " .. UnitBaseName .. "in " .. filename)
+
+        end
+        if(curBlueprint.Merge) then
+            --dosomething
+            print("Skipping " .. UnitBaseName .. "in " .. filename)
+        end
+
+
+        -- trap for multiple BPs coming from one *_unit.bp file
+        local BPnum = 1
+        while (countFiles ~= countBPs) do
+            table.insert(allShortIDs, UnitBaseName .. "_" .. BPnum)
+            table.insert(allFullDirs, filename)
+            countFiles = countFiles + 1
+            BPnum = BPnum + 1
+        end 
+
+    end
+
+end
+
+print("...Phx DPS and Threat Run Beginning...")
+local file = io.open(outputFileName, "w+")
+io.output(file)
+io.write(
+                "ID" 
+                .. "," .. "Unit Name"
+                .. "," .. "Tier"
+                .. "," .. "Type"
+                .. "," .. "Type2"
+                .. "," .. "Race"
+                .. "," .. "Chassis"
+                .. "," .. "ThreatSpd"
+                .. "," .. "ThreatRange"
+                .. "," .. "ThreatHP"
+                .. "," .. "SrfThreatTotal"
+                .. "," .. "SubThreatTotal"
+                .. "," .. "AirThreatTotal"
+                .. "," .. "tSurfDPS"
+                .. "," .. "tSubDPS"
+                .. "," .. "tAirDPS"
+                .. "," .. "totDPS"
+                .. "," .. "maxRange"
+                .. "," .. "Vision"
+                .. "," .. "Wvision"
+                .. "," .. "Intel"
+                .. "," .. "Shield"
+                .. "," .. "Health"
+                .. "," .. "TorpDefRate"
+                .. "," .. "Regen"
+                .. "," .. "Mass"
+                .. "," .. "Energy"
+                .. "," .. "BuildTime"
+                .. "," .. "Speed"
+                .. "," .. "Warnings"
+                .. "\n"
+            )
+
+for curBPid,curBP in ipairs(allBlueprints) do
+    local curShortID = (allShortIDs[curBPid] or "None")
+
+    local Mass = 0
+    local Energy = 0
+    local BuildTime = 0
+    local Tier = 0
+    local Vision = 0
+    local Wvision = 0
+    local TorpDefRate = 0
+    local Race = 'none'
+    local Chassis = 'unknown'
+    local Intel = ''
+
+    local unitDPS = calcUnitDPS(curShortID,curBP)
+
+    -- Get Economic values for Mass Energy and BuildTime if they exist
+    if curBP.Economy then
+        Energy = curBP.Economy.BuildCostEnergy or 0
+        Mass = curBP.Economy.BuildCostMass or 0
+        BuildTime = curBP.Economy.BuildCostMass or 0
+    else 
+        Energy = 0
+        Mass = 0
+        BuildTime = 0
+    end
+
+    Tier = getTechLevel(curBP)
+    Vision = getVision(curBP)
+    Wvision = getWaterVision(curBP)
+    Chassis = PhxLib.getChassis(curBP)
+    Intel = PhxLib.getIntel(curBP)
+    TorpDefRate = PhxLib.getAntiTorpRate(curBP)
+
+    if curBP.General and curBP.General.FactionName then 
+        Race = curBP.General.FactionName
+    end
+    
+    --Record Unit Stats to output file
+    io.write(
+        curShortID 
+        .. "," .. cleanUnitName(curBP)
+        .. "," .. Tier
+        .. "," .. "Type"
+        .. "," .. "Type2"
+        .. "," .. Race
+        .. "," .. Chassis
+        .. "," .. unitDPS.Threat.Speed
+        .. "," .. unitDPS.Threat.Range
+        .. "," .. unitDPS.Threat.HP
+        .. "," .. unitDPS.Threat.srfTotal
+        .. "," .. unitDPS.Threat.subTotal
+        .. "," .. unitDPS.Threat.airTotal
+        .. "," .. unitDPS.srfDPS
+        .. "," .. unitDPS.subDPS
+        .. "," .. unitDPS.airDPS
+        .. "," .. unitDPS.totDPS
+        .. "," .. unitDPS.maxRange
+        .. "," .. Vision
+        .. "," .. Wvision
+        .. "," .. Intel
+        .. "," .. unitDPS.Shield
+        .. "," .. unitDPS.Health
+        .. "," .. TorpDefRate
+        .. "," .. unitDPS.Regen
+        .. "," .. Mass
+        .. "," .. Energy
+        .. "," .. BuildTime
+        .. "," .. unitDPS.Speed
+        .. "," .. unitDPS.Warn
+        .. "\n"
+    )
+end -- Blueprint for() Loop
+
+io.close(file)
+
+print("****************************************************")
+print("  Threat Parser Complete, starting interactive LUA  ")
+print("                 press CTRL-D to exit")
+print("****************************************************")


### PR DESCRIPTION
Made a few minor changes to allow lua_utils (command line lua) blue print extractor to work again with Spout's recent changes to PhxLib.

1.) != is not supported in command line lua, change to ~=

2.)  removed use of "continue" as it is not supported in command line lua.  Work around is to return a valid "null" weapDPS object. Now it will skip PhxLib.PhxWeapDPS() but still return a weapon with zero contribution to range, damage, dps, etc. Also, needed to tweak the accumulators so they will work with zero threat.

3.) Updated ThreatParser to v007 so it no longer gags on the use of LOG() and repr() functions.  
4.) Generated a new ..\lua_utils\bluePrintExtractor\LOUD_UnitDB_v007.csv