### PR TITLE
Minimap Resource Option Fix

### DIFF
--- a/gamedata/lua/lua/ui/game/minimap.lua
+++ b/gamedata/lua/lua/ui/game/minimap.lua
@@ -11,7 +11,7 @@ local Window = import('/lua/maui/window.lua').Window
 local Prefs = import('/lua/user/prefs.lua')
 
 local minimap = Prefs.GetFromCurrentProfile('stratview') or false
-local minimap_resources = Prefs.GetFromCurrentProfile('minimap_resources') or false
+local minimap_resources = Prefs.GetFromCurrentProfile('MiniMap_resource_icons') or false
 
 controls = {
     displayGroup = false,


### PR DESCRIPTION
- Corrected function for retrieving setting in players .prefs file for viewing minimap resources. The name that was being searched for in the .prefs file was 'minimap_resources' when it should be 'MiniMap_resource_icons'.