### PR TITLE
LUA - Relocate Starting Resources Fix

### DIFF
--- a/gamedata/lua/lua/sim/ScenarioUtilities.lua
+++ b/gamedata/lua/lua/sim/ScenarioUtilities.lua
@@ -440,7 +440,7 @@ function CreateResources()
                             end
 						
                         -- if there are AI then ALWAYS relocate unused start positions  - just a little bit closer than standard
-						elseif AI and not doit then
+						elseif AI or ScenarioInfo.Options.RelocateResources == 'on' and not doit then
                         
                             local adjust = 23
                             

--- a/gamedata/lua/lua/ui/help/tooltips.lua
+++ b/gamedata/lua/lua/ui/help/tooltips.lua
@@ -1420,15 +1420,15 @@ Tooltips = {
 
     Lobby_RelocateResources = {
         title = "Relocate Starting Resources",
-        description = "Starting mass and hydrocarbon points, at start positions, are relocated to suit AI players.",
+        description = "Initial mass & hydrocarbon points are relocated to suit AI needs.",
     },
     lob_RelocateResources_on = {
         title = 'On',
-        description = "Starting mass and hydrocarbon points, at ALL start positions, are relocated to suit AI players.",
+        description = "Mass and hydrocarbon points at ALL starting positions are relocated.",
     },
     lob_RelocateResources_off = {
         title = 'Off',
-        description = "Starting mass and hydrocarbon points, at AI start positions ONLY, are relocated, to suit AI players.",
+        description = "Mass and hydrocarbon points at HUMAN starting positions are NOT relocated.",
     },
  
     -- **********************

--- a/gamedata/lua/lua/ui/lobby/lobbyOptions.lua
+++ b/gamedata/lua/lua/ui/lobby/lobbyOptions.lua
@@ -509,12 +509,12 @@ advGameOptions = {
         values = {
             {
                 text = 'On',
-                help = "Mass and hydrocarbon points at ALL starting postions are relocated.",
+                help = "Mass and hydrocarbon points at ALL starting positions are relocated.",
                 key = 'on',
             },
             {
                 text = 'Off',
-                help = "Mass and hydrocarbon points at HUMAN start positions are NOT relocated.",
+                help = "Mass and hydrocarbon points at HUMAN starting positions are NOT relocated.",
                 key = 'off',
             },
         }


### PR DESCRIPTION
- Update function looking at unoccupied starting locations to process relocating resources when no AIs are present but lobby option is On.
- Update tooltips.