### PR TITLE
UNITS - Nuke Sub Range Fix

### DIFF
--- a/gamedata/units/units/UAS0304/UAS0304_unit.bp
+++ b/gamedata/units/units/UAS0304/UAS0304_unit.bp
@@ -307,7 +307,7 @@ UnitBlueprint {
                 },
             },
 
-            RangeCategory = 'UWRC_IndirectFire',
+            RangeCategory = 'UWRC_DirectFire',
 			
             RateOfFire = 0.1,		-- 2400 dmg every 10 seconds = 240 DPS Surface
 			
@@ -356,7 +356,7 @@ UnitBlueprint {
 			
             MaxProjectileStorage = 3,
 			
-            MaxRadius = 1536,
+            MaxRadius = 1024,
             MinRadius = 128,
 
             MuzzleVelocity = 0,
@@ -373,7 +373,6 @@ UnitBlueprint {
             NukeWeapon = true,
 			
             ProjectileId = '/projectiles/AIFQuantumWarhead03/AIFQuantumWarhead03_proj.bp',
-			ProjectileLifetime = 60,
 			
             RackBones = {
                 {
@@ -382,7 +381,7 @@ UnitBlueprint {
                 },
             },
 
-            RangeCategory = 'UWRC_DirectFire',
+            RangeCategory = 'UWRC_IndirectFire',
 			
             RateOfFire = 1,
 			

--- a/gamedata/units/units/UES0304/UES0304_unit.bp
+++ b/gamedata/units/units/UES0304/UES0304_unit.bp
@@ -321,7 +321,7 @@ UnitBlueprint {
                 },
             },
 
-            RangeCategory = 'UWRC_IndirectFire',
+            RangeCategory = 'UWRC_DirectFire',
 			
             RateOfFire = 0.1, 	---- 6 missiles = 3600 dmg every 10 seconds = 360 DPS
 			
@@ -371,7 +371,7 @@ UnitBlueprint {
 
             MaxProjectileStorage = 3,
 
-            MaxRadius = 1536,
+            MaxRadius = 1024,
             MinRadius = 128,
 
             MuzzleVelocity = 0,
@@ -398,6 +398,8 @@ UnitBlueprint {
                     RackBone = 'Center_Hatch02',
                 },
             },
+
+            RangeCategory = 'UWRC_IndirectFire',
 
             RateOfFire = 1,
             TargetCheckInterval = 0.5,

--- a/gamedata/units/units/URS0304/URS0304_unit.bp
+++ b/gamedata/units/units/URS0304/URS0304_unit.bp
@@ -337,7 +337,7 @@ UnitBlueprint {
                 },
             },
 
-            RangeCategory = 'UWRC_IndirectFire',
+            RangeCategory = 'UWRC_DirectFire',
 			
             RateOfFire = 0.2,		-- 3 missiles * 500 = 1500 dmg / 5 = 300 DPS Surface
             TargetCheckInterval = 2,
@@ -454,7 +454,7 @@ UnitBlueprint {
 			
             MaxProjectileStorage = 3,
 			
-            MaxRadius = 1536,
+            MaxRadius = 1024,
             MinRadius = 128,
 
             MuzzleVelocity = 0,
@@ -471,7 +471,6 @@ UnitBlueprint {
             NukeWeapon = true,
 			
             ProjectileId = '/projectiles/CIFEMPFluxWarhead04/CIFEMPFluxWarhead04_proj.bp',
-			ProjectileLifetime = 45,
 
             RackBones = {
                 {
@@ -479,6 +478,8 @@ UnitBlueprint {
                     RackBone = 'Projectile_Center',
                 },
             },
+
+            RangeCategory = 'UWRC_IndirectFire',
 
             RateOfFire = 1,
 

--- a/gamedata/units/units/XSS0302/XSS0302_unit.bp
+++ b/gamedata/units/units/XSS0302/XSS0302_unit.bp
@@ -876,7 +876,6 @@ UnitBlueprint {
             NukeWeapon = true,
 			
             ProjectileId = '/projectiles/SIFInainoStrategicMissile02/SIFInainoStrategicMissile02_proj.bp',
-			ProjectileLifetime = 150,
 
             RackBones = {
                 {


### PR DESCRIPTION
- Added/corrected RangeCategory for nuke weapon of T3 Strategic Missile Submarines & Sera T3 Battleship.
- Corrected MaxRadius of nuke subs to match Sera T3 Battleship.
- Removed ProjectileLifetime for nuke weapons to avoid premature detonation in mid-air while missile was en route to target location.
- Units affected:
 |--> Aeon Silencer T3 Strategic Missile Submarine (uas0304)
 |--> Cybran Plan B T3 Strategic Missile Submarine (urs0304)
 |--> Sera Hauthuum T3 Battleship (xss0302)
 |--> UEF Ace T3 Strategic Missile Submarine (ues0304)