### PR TITLE
LOUD Dev and Release Init File Updates

### DIFF
--- a/bin/LoudDataPath.lua
+++ b/bin/LoudDataPath.lua
@@ -16,29 +16,33 @@ local function mount_contents(dir, mountpoint)
     end
 end
 
---Original game content
-mount_dir(InitFileDir .. '\\..\\..\\fonts', '/fonts')
-mount_dir(InitFileDir .. '\\..\\..\\sounds', '/sounds')
-mount_dir(InitFileDir .. '\\..\\..\\movies', '/movies')
+--LOUD Strat Icons - various sizes
+mount_dir(InitFileDir .. '\\..\\usermods\\BrewLAN-StrategicIcons*.scd', '/')
 
---Load LOUD content first, and then follow up with any missing vanilla content.
+--LOUD content
 mount_dir(InitFileDir .. '\\..\\gamedata\\*.scd', '/')
-mount_dir(InitFileDir .. '\\..\\..\\gamedata\\textures.scd', '/')
-mount_dir(InitFileDir .. '\\..\\..\\gamedata\\effects.scd', '/')
-mount_dir(InitFileDir .. '\\..\\..\\gamedata\\projectiles.scd', '/')
-mount_dir(InitFileDir .. '\\..\\..\\gamedata\\env.scd', '/')
-mount_dir(InitFileDir .. '\\..\\..\\gamedata\\props.scd', '/')
-mount_dir(InitFileDir .. '\\..\\..\\gamedata\\meshes.scd', '/')
-
-mount_dir(InitFileDir .. '\\..\\usermods\\*.scd', '/')
-mount_dir(InitFileDir .. '\\..\\usermods', '/mods')
-mount_contents(InitFileDir .. '\\..\\maps', '/maps')
-mount_contents(InitFileDir .. '\\..\\usermaps', '/maps')
+mount_dir(InitFileDir .. '\\..\\maps', '/maps')
 mount_dir(InitFileDir .. '\\..\\sounds', '/sounds')
 
---User mods & maps
+--Vanilla content
+mount_dir(InitFileDir .. '\\..\\..\\fonts', '/fonts')
+mount_dir(InitFileDir .. '\\..\\..\\gamedata\\textures.scd', '/')
+mount_dir(InitFileDir .. '\\..\\..\\gamedata\\effects.scd', '/')
+mount_dir(InitFileDir .. '\\..\\..\\gamedata\\env.scd', '/')
+mount_dir(InitFileDir .. '\\..\\..\\gamedata\\projectiles.scd', '/')
+mount_dir(InitFileDir .. '\\..\\..\\gamedata\\props.scd', '/')
+mount_dir(InitFileDir .. '\\..\\..\\gamedata\\meshes.scd', '/')
+mount_dir(InitFileDir .. '\\..\\..\\movies', '/movies')
+mount_dir(InitFileDir .. '\\..\\..\\sounds', '/sounds')
+
+--LOUD directory user maps & mods
+mount_dir(InitFileDir .. '\\..\\usermaps', '/maps')
+mount_dir(InitFileDir .. '\\..\\usermods', '/mods')
+
+--Documents directory user maps & mods (SCFA default)
+--mount_contents(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\maps', '/maps')
 --mount_contents(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods', '/mods')
-mount_contents(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\maps', '/maps')
+
 
 hook = {
     '/schook'
@@ -47,9 +51,4 @@ hook = {
 protocols = {
     'http',
     'https',
-    'mailto',
-    'ventrilo',
-    'teamspeak',
-    'daap',
-    'im',
 }

--- a/bin/SupComDataPath.lua
+++ b/bin/SupComDataPath.lua
@@ -1,4 +1,3 @@
-
 path = {}
 
 local function mount_dir(dir, mountpoint)
@@ -17,35 +16,44 @@ local function mount_contents(dir, mountpoint)
     end
 end
 
---Original game content
+--LOUD Strat Icons - various sizes
+mount_dir(InitFileDir .. '\\..\\..\\LOUD\\usermods\\BrewLAN-StrategicIcons*.scd', '/')
 
---mount_contents(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods', '/mods')
---mount_contents(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\maps', '/maps')
---mount_dir(InitFileDir .. '\\..\\gamedata\\*.scd', '/')
-mount_dir(InitFileDir .. '\\..\\gamedata\\lua\\lua', '/lua')
-mount_dir(InitFileDir .. '\\..\\gamedata\\loc_US\\loc', '/loc')
-mount_dir(InitFileDir .. '\\..\\gamedata\\textures\\textures', '/textures')
-mount_dir(InitFileDir .. '\\..\\..\\gamedata\\textures.scd', '/')
-mount_dir(InitFileDir .. '\\..\\..\\gamedata\\meshes.scd', '/')
-mount_dir(InitFileDir .. '\\..\\gamedata\\effects\\effects', '/effects')
-mount_dir(InitFileDir .. '\\..\\..\\gamedata\\effects.scd', '/')
-mount_dir(InitFileDir .. '\\..\\..\\gamedata\\props.scd', '/')
-mount_dir(InitFileDir .. '\\..\\gamedata\\env\\env', '/env')
-mount_dir(InitFileDir .. '\\..\\..\\gamedata\\env.scd', '/')
-mount_dir(InitFileDir .. '\\..\\gamedata\\projectiles\\projectiles', '/projectiles')
-mount_dir(InitFileDir .. '\\..\\..\\gamedata\\projectiles.scd', '/')
-mount_dir(InitFileDir .. '\\..\\gamedata\\units\\units', '/units')
+--Git-LOUD content
+mount_dir(InitFileDir .. '\\..\\gamedata\\4D-CompatabilityPack\\mods', '/mods')
+mount_dir(InitFileDir .. '\\..\\gamedata\\TotalMayhem\\mods', '/mods')
+mount_dir(InitFileDir .. '\\..\\gamedata\\WyvernBattlePack\\mods', '/mods')
+mount_dir(InitFileDir .. '\\..\\gamedata\\WyvernBattlePack\\Sounds', '/sounds')
+mount_dir(InitFileDir .. '\\..\\gamedata\\WyvernBattlePack\\textures', '/textures')
+mount_dir(InitFileDir .. '\\..\\gamedata\\BlackOps\\mods', '/mods')
+mount_dir(InitFileDir .. '\\..\\gamedata\\BrewLAN_LOUD\\mods', '/mods')
 mount_dir(InitFileDir .. '\\..\\gamedata\\civ_units\\units', '/units')
-mount_dir(InitFileDir .. '\\..\\..\\gamedata\\units.scd', '/')
+mount_dir(InitFileDir .. '\\..\\gamedata\\effects\\effects', '/effects')
+mount_dir(InitFileDir .. '\\..\\gamedata\\env\\env', '/env')
+mount_dir(InitFileDir .. '\\..\\gamedata\\extra_env\\env', '/env')
+mount_dir(InitFileDir .. '\\..\\gamedata\\loc_US\\loc', '/loc')
 mount_dir(InitFileDir .. '\\..\\gamedata\\LOUD_Misc\\mods', '/mods')
 mount_dir(InitFileDir .. '\\..\\gamedata\\LOUD_Units\\mods', '/mods')
-mount_dir(InitFileDir .. '\\..\\gamedata\\TotalMayhem\\mods', '/mods')
-mount_dir(InitFileDir .. '\\..\\gamedata\\BlackOps\\mods', '/mods')
-mount_dir(InitFileDir .. '\\..\\gamedata\\4D-CompatabilityPack\\mods', '/mods')
-mount_dir(InitFileDir .. '\\..\\gamedata\\WyvernBattlePack\\textures', '/textures')
-mount_dir(InitFileDir .. '\\..\\gamedata\\WyvernBattlePack\\Sounds', '/sounds')
-mount_dir(InitFileDir .. '\\..\\gamedata\\WyvernBattlePack\\mods', '/mods')
-mount_dir(InitFileDir .. '\\..\\gamedata\\BrewLAN_LOUD\\mods', '/mods')
+mount_dir(InitFileDir .. '\\..\\gamedata\\lua\\lua', '/lua')
+mount_dir(InitFileDir .. '\\..\\gamedata\\projectiles\\projectiles', '/projectiles')
+mount_dir(InitFileDir .. '\\..\\gamedata\\textures\\textures', '/textures')
+mount_dir(InitFileDir .. '\\..\\gamedata\\units\\units', '/units')
+mount_dir(InitFileDir .. '\\..\\sounds', '/sounds')
+
+--LOUD content
+mount_dir(InitFileDir .. '\\..\\..\\LOUD\\maps', '/maps')
+
+--Vanilla content
+mount_dir(InitFileDir .. '\\..\\..\\fonts', '/fonts')
+mount_dir(InitFileDir .. '\\..\\..\\gamedata\\textures.scd', '/')
+mount_dir(InitFileDir .. '\\..\\..\\gamedata\\effects.scd', '/')
+mount_dir(InitFileDir .. '\\..\\..\\gamedata\\env.scd', '/')
+mount_dir(InitFileDir .. '\\..\\..\\gamedata\\projectiles.scd', '/')
+mount_dir(InitFileDir .. '\\..\\..\\gamedata\\props.scd', '/')
+mount_dir(InitFileDir .. '\\..\\..\\gamedata\\meshes.scd', '/')
+mount_dir(InitFileDir .. '\\..\\..\\movies', '/movies')
+mount_dir(InitFileDir .. '\\..\\..\\sounds', '/sounds')
+
 --Versioning
 mount_dir(InitFileDir .. '\\..\\gamedata\\loc_US\\lua', '/lua')
 mount_dir(InitFileDir .. '\\..\\gamedata\\textures\\lua', '/lua')
@@ -60,14 +68,15 @@ mount_dir(InitFileDir .. '\\..\\gamedata\\BlackOps\\lua', '/lua')
 mount_dir(InitFileDir .. '\\..\\gamedata\\4D-CompatabilityPack\\lua', '/lua')
 mount_dir(InitFileDir .. '\\..\\gamedata\\BrewLAN_LOUD\\lua', '/lua')
 mount_dir(InitFileDir .. '\\..\\gamedata\\WyvernBattlePack\\lua', '/lua')
---Non Game-data
-mount_contents(InitFileDir .. '\\..\\..\\LOUD\\maps', '/maps')
-mount_contents(InitFileDir .. '\\..\\..\\LOUD\\usermaps', '/maps')
+
+--LOUD directory user maps & mods
+mount_dir(InitFileDir .. '\\..\\..\\LOUD\\usermaps', '/maps')
 mount_dir(InitFileDir .. '\\..\\..\\LOUD\\usermods', '/mods')
-mount_dir(InitFileDir .. '\\..\\sounds', '/sounds')
-mount_dir(InitFileDir .. '\\..\\..\\movies', '/movies')
-mount_dir(InitFileDir .. '\\..\\..\\fonts', '/fonts')
-mount_dir(InitFileDir .. '\\..\\..\\sounds', '/sounds')
+
+--Documents directory user maps & mods (SCFA default)
+--mount_contents(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\maps', '/maps')
+--mount_contents(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods', '/mods')
+
 
 hook = {
     '/schook'
@@ -78,9 +87,4 @@ hook = {
 protocols = {
     'http',
     'https',
-    'mailto',
-    'ventrilo',
-    'teamspeak',
-    'daap',
-    'im',
 }


### PR DESCRIPTION
- Removed line in LOUD Dev init file (SupComDataPath.lua) that told the dev environment to load the units.scd file from the vanilla SCFA install.
- Added line to Dev init to load the extra_env directory added to the repo in June 2022.
- Edited LOUD Dev & Release init files to mirror each other to make future edits easier to follow from one to the other.