### PR TITLE
Supreme Economy cleanup and fixes

### DIFF
--- a/gamedata/LOUD_Misc/mods/SupremeEconomy/hook/lua/ui/game/gamemain.lua
+++ b/gamedata/LOUD_Misc/mods/SupremeEconomy/hook/lua/ui/game/gamemain.lua
@@ -1,16 +1,16 @@
-local originalCreateUI = CreateUI 
+local originalCreateUI = CreateUI
 local modFolder = 'SupremeEconomy'
 local UpdateAllUnits = import('/mods/' .. modFolder .. '/modules/mciallunits.lua').UpdateAllUnits
 
 function CreateUI(isReplay)
- 
-  originalCreateUI(isReplay) 
- 
+
+  originalCreateUI(isReplay)
+
   local parent = import('/lua/ui/game/borders.lua').GetMapGroup()
-  
+
   AddBeatFunction(UpdateAllUnits)
-  
+
   import('/mods/' .. modFolder .. '/modules/resourceusage.lua').CreateModUI(isReplay, parent)
   import('/mods/' .. modFolder .. '/modules/mexes.lua').CreateModUI(isReplay, parent)
-  
+
 end

--- a/gamedata/LOUD_Misc/mods/SupremeEconomy/hook/lua/ui/game/scoreaccum.lua
+++ b/gamedata/LOUD_Misc/mods/SupremeEconomy/hook/lua/ui/game/scoreaccum.lua
@@ -1,9 +1,10 @@
 local originalUpdateScoreData = UpdateScoreData
 local modFolder = 'SupremeEconomy'
+local SEUpdateScoreData = import('/mods/' .. modFolder .. '/modules/mciscore.lua').UpdateScoreData
 
 function UpdateScoreData(newData)
 
   originalUpdateScoreData(newData)
 
-  import('/mods/' .. modFolder .. '/modules/mciscore.lua').UpdateScoreData(newData)
+  SEUpdateScoreData(newData)
 end

--- a/gamedata/LOUD_Misc/mods/SupremeEconomy/hook/lua/ui/game/scoreaccum.lua
+++ b/gamedata/LOUD_Misc/mods/SupremeEconomy/hook/lua/ui/game/scoreaccum.lua
@@ -1,9 +1,9 @@
 local originalUpdateScoreData = UpdateScoreData
 local modFolder = 'SupremeEconomy'
 
-function UpdateScoreData(newData) 
+function UpdateScoreData(newData)
 
   originalUpdateScoreData(newData)
-  
+
   import('/mods/' .. modFolder .. '/modules/mciscore.lua').UpdateScoreData(newData)
 end

--- a/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/mciallunits.lua
+++ b/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/mciallunits.lua
@@ -9,17 +9,17 @@ function AddSelection()
 	for _, unit in (GetSelectedUnits() or {}) do
 		allUnits[unit:GetEntityId()] = unit
 	end
-	
+
 end
 
 function Reset()
 
 	local currentlySelected = GetSelectedUnits() or {}
-	
+
 	UISelectionByCategory("ALLUNITS", false, false, false, false)
 	AddSelection()
 	SelectUnits(currentlySelected)
-	
+
 end
 
 local emergencyResetProcedureStarted = false
@@ -27,16 +27,16 @@ local emergencyResetProcedureStarted = false
 function EmergencyReset(targetUnitCount)
 
 	WaitSeconds(10)
-	
+
 	local newTargetUnitCount = GetScore()[GetFocusArmy()].general.currentunits.count
-	
+
 	-- if after 10 seconds we are not loosing units and the unit count is still larger we have to do a reset
 	if newTargetUnitCount >= targetUnitCount and newTargetUnitCount > table.getsize(allUnits)  then
 		print("Supreme Economy: New units detected, selecting units in 1 second!")
 		WaitSeconds(1)
 		Reset()
 	end
-	
+
 	emergencyResetProcedureStarted = false
 end
 
@@ -48,39 +48,39 @@ function UpdateAllUnits()
 	end
 
 	AddSelection()
-	
+
 	-- add focused (building or assisting)
 	for _, unit in allUnits do
-	
+
 		if not unit:IsDead() and unit:GetFocus() and not unit:GetFocus():IsDead()then
 			allUnits[unit:GetFocus():GetEntityId()] = unit:GetFocus()
 		end
-		
+
 	end
-	
+
 	-- remove dead
 	for entityid, unit in allUnits do
-	
+
 		if unit:IsDead() then
 			allUnits[entityid] = nil
 		end
-		
+
 	end
-	
+
 	-- emergency reset
 	local targetNumOfUnits = GetScore()[GetFocusArmy()].general.currentunits.count
-	
+
 	if not emergencyResetProcedureStarted and targetNumOfUnits > table.getsize(allUnits) then
-	
+
 		emergencyResetProcedureStarted = true
 		ForkThread(EmergencyReset, targetNumOfUnits)
-		
+
 	end
-	
+
 end
 
 function GetAllUnits()
 
 	return allUnits
-	
+
 end

--- a/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/mcibuttons.lua
+++ b/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/mcibuttons.lua
@@ -81,7 +81,7 @@ end
 
 function CreateTextBG(parent, control, color)
 
-	background = Bitmap(control)
+	local background = Bitmap(control)
 	background:SetSolidColor(color)
 	background.Top:Set(control.Top)
 	background.Left:Set(control.Left)

--- a/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/mcibuttons.lua
+++ b/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/mcibuttons.lua
@@ -1,4 +1,4 @@
-local LayoutHelpers = import('/lua/maui/layouthelpers.lua') 
+local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 local Button = import('/lua/maui/button.lua').Button
 local Bitmap = import('/lua/maui/bitmap.lua').Bitmap
 local ItemList = import('/lua/maui/itemlist.lua').ItemList
@@ -40,43 +40,43 @@ function PrintUnitDebugInfo(unit)
 	LOG("GetWorkProgress " .. repr(unit:GetWorkProgress()))
 	LOG("IsRepeatQueue " .. repr(unit:IsRepeatQueue()))
 	LOG("IsStunned " .. repr(unit:IsStunned()))
-	
+
 	LOG("IsAutoMode " .. repr(unit:IsAutoMode()))
 	LOG("IsAutoSurfaceMode " .. repr(unit:IsAutoSurfaceMode()))
 	LOG("IsDead " .. repr(unit:IsDead()))
-	
+
 end
 
 function CreateGrid(parent, x, y, cols, rows, CreateFunc)
 
 	local grid = {}
-	
+
 	for col = 1,cols do
-	
+
 		grid[col] = {}
-		
+
 		for row = 1,rows do
-		
+
 			grid[col][row] = CreateFunc(parent)
-			
+
 			if row > 1 then
 				LayoutHelpers.Below(grid[col][row], grid[col][row-1], 0)
 			else
 				LayoutHelpers.AtTopIn(grid[col][row], parent, y)
 			end
-			
+
 			if col > 1 then
 				LayoutHelpers.RightOf(grid[col][row], grid[col-1][row], 0)
 			else
 				LayoutHelpers.AtLeftIn(grid[col][row], parent, x)
 			end
-			
+
 		end
-		
+
 	end
-	
+
 	return grid
-	
+
 end
 
 function CreateTextBG(parent, control, color)
@@ -88,62 +88,62 @@ function CreateTextBG(parent, control, color)
 	background.Right:Set(control.Right)
 	background.Bottom:Set(control.Bottom)
 	background.Depth:Set(function() return parent.Depth() + 1 end)
-	
+
 end
 
 function CreateGenericButton(parent)
 
 	local buttonBackgroundName = UIUtil.SkinnableFile('/game/avatar-factory-panel/avatar-s-e-f_bmp.dds')
-	
+
 	local bg = Bitmap(parent, buttonBackgroundName)
 
     bg.Height:Set(44)
     bg.Width:Set(44)
-	
-	bg.units = {}	
+
+	bg.units = {}
 	bg.HandleEvent = AvatarsClickFunc
-	
+
 	bg.marker = Bitmap(bg)
 	bg.marker:SetTexture(UIUtil.UIFile('/game/avatar/pulse-bars_bmp.dds'))
 	bg.marker.Height:Set(54)
 	bg.marker.Width:Set(54)
-	
+
 	LayoutHelpers.AtLeftTopIn(bg.marker, bg, -5, -5)
-	
+
 	bg.icon = Bitmap(bg)
     bg.icon.Height:Set(34)
     bg.icon.Width:Set(34)
-	
+
 	LayoutHelpers.AtLeftTopIn(bg.icon, bg, 5, 5)
-	
+
 	bg.progress = StatusBar(bg, 0, 1, false, false,
 							UIUtil.UIFile('/game/unit-over/health-bars-back-1_bmp.dds'),
 							UIUtil.UIFile('/game/unit-over/bar01_bmp.dds'), true, "Unit RO Health Status Bar")
-	
+
 	bg.progress.Width:Set(32)
     bg.progress.Height:Set(0)
-	
+
     LayoutHelpers.AtLeftTopIn(bg.progress, bg, 6, 2)
-    
-	
+
+
     bg.income = UIUtil.CreateText(bg.icon, '', 13, UIUtil.bodyFont)
 	bg.income:SetColor('ffff8f00')
     --bg.income:SetDropShadow(true)
-	
+
 	LayoutHelpers.AtTopIn(bg.income, bg.icon, 0)
     LayoutHelpers.AtRightIn(bg.income, bg.icon, 1)
-	
+
 	CreateTextBG(bg, bg.income, '77000000')
-	
+
 	bg.count = UIUtil.CreateText(bg.icon, '', 11, UIUtil.bodyFont)
 	bg.count:SetColor('ffffffff')
     --bg.count:SetDropShadow(true)
-	
+
 	LayoutHelpers.AtBottomIn(bg.count, bg.icon, 0)
     LayoutHelpers.AtRightIn(bg.count, bg.icon, 2)
-	
+
 	CreateTextBG(bg, bg.count, '77000000')
-	
+
 	return bg
-	
+
 end

--- a/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/mexes.lua
+++ b/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/mexes.lua
@@ -187,7 +187,7 @@ function CreateModUI(isReplay, parent)
 
 	for tech = 1, 3 do
 
-		img = Bitmap(parent)
+		local img = Bitmap(parent)
 		img:SetTexture(UIUtil.UIFile('/game/avatar-engineers-panel/tech-'.. tech .. '_bmp.dds'))
 		LayoutHelpers.CenteredLeftOf(img, buttons[1][tech], -6)
 

--- a/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/mexes.lua
+++ b/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/mexes.lua
@@ -1,4 +1,4 @@
-local LayoutHelpers = import('/lua/maui/layouthelpers.lua') 
+local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 local Button = import('/lua/maui/button.lua').Button
 local Bitmap = import('/lua/maui/bitmap.lua').Bitmap
 local ItemList = import('/lua/maui/itemlist.lua').ItemList
@@ -24,60 +24,60 @@ function getNameFromBp(bp)
 
 	local techLevel = false
     local levels = {TECH1 = 1,TECH2 = 2,TECH3 = 3}
-	
+
     for i, v in bp.Categories do
-	
+
         if levels[v] then
             techLevel = levels[v]
             break
         end
     end
-	
+
     if techLevel then
         return LOCF("T%d %s", techLevel, bp.Description)
 	else
 		return LOC(bp.Description)
     end
-	
+
 end
 
 function getMassProducedWithoutMS(unit)
 
 	if EntityCategoryContains(categories.TECH1, unit) then
 		return 2
-		
+
 	elseif EntityCategoryContains(categories.TECH2, unit) then
 		return 6
-		
+
 	elseif EntityCategoryContains(categories.TECH3, unit) then
 		return 18
-		
+
 	else
 		print("Unknown tech level for mass extractor!")
 	end
-	
+
 end
 
 function insertMex(mextable, unit)
 
 	if unit:GetFocus() and EntityCategoryContains(categories.MASSEXTRACTION, unit:GetFocus()) then
-	
+
 		LOUDINSERT(mextable.U.Y, unit)
-		
+
 	else
-	
+
 		LOUDINSERT(mextable.U.N, unit)
-		
+
 	end
-	
+
 	local econoData = unit:GetEconData()
 	--print (econoData.massProduced .. "." .. getMassProducedWithoutMS(unit) .. "." .. repr(econoData.massProduced <= getMassProducedWithoutMS(unit)))
-	
+
 	if econoData.energyRequested == econoData.energyConsumed and econoData.massProduced <= getMassProducedWithoutMS(unit) and econoData.energyRequested > 0 then
-	
+
 		LOUDINSERT(mextable.MS.N, unit)
 	end
-	
+
 end
 
 -- this is not super precise, if you have a damaged disabled mex it will be counted as beeing built
@@ -90,25 +90,25 @@ function isMexBeingBuilt(mex)
 	if mex:GetHealth() == mex:GetMaxHealth() then
 		return false
 	end
-	
+
 	return true
-	
+
 end
 
 function mexesThatAreNotBeeingBuilt(mexes)
 
 	local newMexes = {}
-	
+
 	for _, mex in mexes do
-	
+
 		if not isMexBeingBuilt(mex) then
 			LOUDINSERT(newMexes, mex)
 		end
-		
+
 	end
-	
+
 	return newMexes
-	
+
 end
 
 function updateButton(mexTable, button, enableMarker, tooltipText, countBeingBuilt)
@@ -116,137 +116,137 @@ function updateButton(mexTable, button, enableMarker, tooltipText, countBeingBui
 	if not countBeingBuilt then
 		mexTable = mexesThatAreNotBeeingBuilt(mexTable)
 	end
-	
+
 	local aliveCount = table.getsize(mexTable)
-	
+
 	if aliveCount > 0 then
-	
+
 		local unitBluePrint = mexTable[1]:GetBlueprint()
-		
+
 		ToolTip.AddControlTooltip(button, {text=getNameFromBp(unitBluePrint), body=tooltipText})
-		
+
 		-- assign units that will be selected when the button is clicked
 		button.units = mexTable
 		button.count:SetText(aliveCount)
-		
+
 		-- set the texture that corresponds to the unit
 		local iconName1 = GameCommon.GetUnitIconPath(unitBluePrint)
-		
+
 		button.icon:SetTexture(iconName1)
-		
+
 		-- show the button
 		button:Show()
-		
+
 		-- show work progress on mexes that are being updated
 		if enableMarker then
-		
+
 			local maxWorkProgress = 0
-			
+
 			for _, mex in mexTable do
 				if mex:GetWorkProgress() > maxWorkProgress then
 					maxWorkProgress = mex:GetWorkProgress()
 				end
 			end
-			
+
 			button.progress.Height:Set(3)
 			button.progress:SetValue(maxWorkProgress)
-			
+
 		else
-		
+
 			button.progress.Height:Set(0)
-			
+
 		end
-		
+
 		-- show the marker
 		if enableMarker then
-		
+
 			button.marker:Show()
-			
+
 		else
-		
+
 			button.marker:Hide()
-			
+
 		end
-		
+
 	else
-	
+
 		button:Hide()
-		
+
 	end
-	
+
 end
 
 function CreateModUI(isReplay, parent)
 
 	local xPosition = 20
 	local yPosition = 420
-	
+
 	local buttons = CreateGrid(parent, xPosition, yPosition, 3, 3, CreateGenericButton)
-    
+
     LOG("*AI DEBUG Mods are "..repr(__active_mods))
 
 	for tech = 1, 3 do
-	
+
 		img = Bitmap(parent)
 		img:SetTexture(UIUtil.UIFile('/game/avatar-engineers-panel/tech-'.. tech .. '_bmp.dds'))
 		LayoutHelpers.CenteredLeftOf(img, buttons[1][tech], -6)
-		
+
 	end
-	
+
 	function UpdateMexes()
-	
+
 		local units = GetAllUnits()
 		local mexes = {}
-		
+
 		mexes[categories.TECH1] = {MS = {Y = {}, N = {}}, U = {Y = {}, N = {}}}
 		mexes[categories.TECH2] = {MS = {Y = {}, N = {}}, U = {Y = {}, N = {}}}
 		mexes[categories.TECH3] = {MS = {Y = {}, N = {}}, U = {Y = {}, N = {}}}
-		
+
 		for index, unit in units do
-		
+
 			if EntityCategoryContains(categories.MASSEXTRACTION, unit) then
-			
+
 				if EntityCategoryContains(categories.TECH1, unit) then
 					insertMex(mexes[categories.TECH1], unit)
-					
+
 				elseif EntityCategoryContains(categories.TECH2, unit) then
 					insertMex(mexes[categories.TECH2], unit)
-					
+
 				elseif EntityCategoryContains(categories.TECH3, unit) then
 					insertMex(mexes[categories.TECH3], unit)
-					
+
 				else
 					print("Unknown tech level for mass extractor!")
 				end
-				
+
 			end
-			
+
 		end
-		
+
 		updateButton(mexes[categories.TECH1].U.N, buttons[1][1], false, "Select idle T1 Mexes", false)
 		updateButton(mexes[categories.TECH1].U.Y, buttons[2][1], true, "Select T1 Mexes that are being updated", false)
-		
+
 		buttons[3][1]:Hide()
-		
+
 		updateButton(mexes[categories.TECH2].U.N, buttons[1][2], false, "Select idle T2 Mexes", false)
 		updateButton(mexes[categories.TECH2].U.Y, buttons[2][2], true, "Select T2 Mexes that are being updated", false)
-        
+
         --if not ScenarioInfo.LOUD_IS_Installed then
             updateButton(mexes[categories.TECH2].MS.N, buttons[3][2], false, "Select T2 Mexes that are not surrounded by mass storage", true)
         --end
-		
+
 		buttons[1][3]:Hide()
 		buttons[2][3]:Hide()
-		
+
 		updateButton(mexes[categories.TECH3].U.N, buttons[1][3], false, "Select idle T3 Mexes", false)
 		updateButton(mexes[categories.TECH3].U.Y, buttons[2][3], true, "Select T3 Mexes that are being updated", false)
-        
+
         --if not ScenarioInfo.LOUD_IS_Installed then
             updateButton(mexes[categories.TECH3].MS.N, buttons[3][3], false, "Select T3 Mexes that are not surrounded by mass storage", true)
         --end
-		
+
 	end
- 
+
 	GameMain.AddBeatFunction(UpdateMexes)
-	
+
 end

--- a/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/resourceusage.lua
+++ b/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/resourceusage.lua
@@ -1,4 +1,4 @@
-local LayoutHelpers = import('/lua/maui/layouthelpers.lua') 
+local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 local Button = import('/lua/maui/button.lua').Button
 local Bitmap = import('/lua/maui/bitmap.lua').Bitmap
 local ItemList = import('/lua/maui/itemlist.lua').ItemList
@@ -20,22 +20,22 @@ function getNameFromBp(bp)
 
 	local techLevel = false
     local levels = {TECH1 = 1,TECH2 = 2,TECH3 = 3}
-	
+
     for i, v in bp.Categories do
-	
+
         if levels[v] then
             techLevel = levels[v]
             break
         end
-		
+
     end
-	
+
     if techLevel then
         return LOCF("T%d %s", techLevel, bp.Description)
 	else
 		return LOC(bp.Description)
     end
-	
+
 end
 
 local maxImages = 5
@@ -62,13 +62,13 @@ local unitClasses = {
 function GetClassForUnit(unit)
 
 	for _, class in unitClasses do
-	
+
 		if EntityCategoryContains(class.category, unit) then
 			return class.name
 		end
-		
+
 	end
-	
+
 	return nil
 end
 
@@ -84,29 +84,29 @@ function UpdateResourceUsage()
 	local CONSTRUCTION = "R"
 	local CONSUMPTION = "C"
 	local consumptionTypes = {}
-	
+
 	for index, unit in units do
-	
+
 		econData = unit:GetEconData()
-		
+
 		-- filter out units that do not use resources
 		local usesResources = false
-		
+
 		for dataType, unitTable in topUnitsData do
-		
+
 			if econData[dataType] != 0 then
 				usesResources = true
 			end
-			
+
 		end
-		
+
 		if usesResources then
 			-- assign a proper key and other misc stuff related to the construction/consumption difference
-			
+
 			local unitToGetDataFrom
 			local prefix
 			local consType
-			
+
 			if unit:GetFocus() then
 				prefix = "-CONSTR- "
 				unitToGetDataFrom = unit:GetFocus()
@@ -118,9 +118,9 @@ function UpdateResourceUsage()
 				consType = CONSUMPTION
 				workProgressOnUnit[unit:GetEntityId()] = unit:GetWorkProgress() --it should be only set in the context of the "name" generated"
 			end
-			
+
 			local unitclass = GetClassForUnit(unitToGetDataFrom)
-			
+
 			if unitclass then
 				name = prefix .. unitclass
 				unitNames[name] = unitclass
@@ -128,164 +128,164 @@ function UpdateResourceUsage()
 				name = prefix .. getNameFromBp(unitToGetDataFrom:GetBlueprint())
 				unitNames[name] = getNameFromBp(unitToGetDataFrom:GetBlueprint())
 			end
-			
+
 			if not unitsWorkedUpon[name] then
 				unitsWorkedUpon[name] = {}
 			end
-			
+
 			LOUDINSERT(unitsWorkedUpon[name], unitToGetDataFrom)
-			
+
 			consumptionTypes[name] = consType
-			
+
 			-- insert the unit as to be selected when the corresponding button is pressed
 			if unitsToBeSelected[name] == nil then
 				unitsToBeSelected[name] = {}
 			end
-			
+
 			LOUDINSERT(unitsToBeSelected[name], unit)
-		
+
 			-- fill out the table that will be used to display the resource using units
 			for dataType, unitTable in topUnitsData do
-			
+
 				if econData[dataType] != 0 then
 					topUnitsData[dataType][name] = (topUnitsData[dataType][name] or 0) + econData[dataType]
 				end
-				
+
 			end
-			
+
 		end
-		
+
 	end
-	
+
 	local dtIndex = 1
-	
+
 	for _, dataType in dataTypes do
-	
+
 		unitTable = topUnitsData[dataType]
-		
+
 		-- sort according to resource usage
 		local sortedTable = {}
-		
+
 		for name, data in unitTable do
 			LOUDINSERT(sortedTable,{name=name, data=data})
 		end
-		
+
 		table.sort(sortedTable, function(a,b) return a.data > b.data end)
-		
+
 		-- hide all buttons
 		for index = 1, maxImages do
 			local button = grid[dtIndex][index]
 			button:Hide()
 		end
-		
+
 		for index, info in sortedTable do
-		
+
 			if index <= maxImages then
-			
+
 				local button = grid[dtIndex][index]
-				
+
 				-- setup the new tooltip
 				local tooltipText
-				
+
 				if consumptionTypes[info.name] == CONSTRUCTION then
 					tooltipText = "Select all units that are constructing " .. unitNames[info.name] .. "."
 				else
 					tooltipText = "Select units."
 				end
-				
+
 				ToolTip.AddControlTooltip(button, {text=unitNames[info.name], body=tooltipText})
-				
+
 				-- assign units that will be selected when the button is clicked
 				button.units = unitsToBeSelected[info.name]
-				
+
 				local unitWithMostProgress = nil
 				local maxWorkProgress = -1
-				
+
 				for _, unit in unitsWorkedUpon[info.name] do
-				
+
 					if workProgressOnUnit[unit:GetEntityId()] > maxWorkProgress then
-					
+
 						maxWorkProgress = workProgressOnUnit[unit:GetEntityId()]
 						unitWithMostProgress = unit
-						
+
 					end
-					
+
 				end
-				
+
 				if maxWorkProgress != 0 then
 					button.progress:SetValue(maxWorkProgress)
 					button.progress.Height:Set(3)
 				else
 					button.progress.Height:Set(0)
 				end
-				
+
 				button.count:SetText(table.getsize(unitsToBeSelected[info.name]))
-				
+
 				-- display the income
 				button.income:SetText("-" .. info.data)
-				
+
 				-- set the texture that corresponds to the unit
 				local iconName1 = GameCommon.GetUnitIconPath(unitWithMostProgress:GetBlueprint())
-				
+
 				button.icon:SetTexture(iconName1)
-				
+
 				-- show the button
 				button:Show()
-				
+
 				-- show the construction marker
 				if consumptionTypes[info.name] == CONSTRUCTION then
 					button.marker:Show()
 				else
 					button.marker:Hide()
 				end
-				
+
 			end
-			
+
 		end
-		
+
 		dtIndex = dtIndex + 1
-		
+
 	end
-	
+
 end
 
 function CreateModUI(isReplay, parent)
 
 	local xPosition = 5
 	local yPosition = 180
-	
+
 	grid = CreateGrid(parent, xPosition, yPosition, 2, maxImages, CreateGenericButton)
-	
+
 	local resourceIconHeight = 32
-	
+
 	local img = Bitmap(parent)
-	
+
 	img.Width:Set(resourceIconHeight/58 * 70)
 	img.Height:Set(resourceIconHeight)
 	img:SetTexture(UIUtil.UIFile('/game/resources/mass_btn_up.dds'))
-	
+
 	LayoutHelpers.CenteredAbove(img, grid[1][1], 0)
-	
+
 	local count = 1
-	
+
 	img.Update = function(self)
 		print("OnUpdate".. count)
 		count = count + 1
 	end
-	
+
 	img.OnFrame = function(self)
 		print("OnFrame".. count)
 		count = count + 1
 	end
-	
+
 	local img = Bitmap(parent)
-	
+
 	img.Width:Set(resourceIconHeight)
 	img.Height:Set(resourceIconHeight)
 	img:SetTexture(UIUtil.UIFile('/game/resources/energy_btn_up.dds'))
-	
+
 	LayoutHelpers.CenteredAbove(img, grid[2][1], 0)
-	
+
 	GameMain.AddBeatFunction(UpdateResourceUsage)
-	
+
 end

--- a/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/resourceusage.lua
+++ b/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/resourceusage.lua
@@ -87,7 +87,7 @@ function UpdateResourceUsage()
 
 	for index, unit in units do
 
-		econData = unit:GetEconData()
+		local econData = unit:GetEconData()
 
 		-- filter out units that do not use resources
 		local usesResources = false
@@ -161,13 +161,13 @@ function UpdateResourceUsage()
 
 	for _, dataType in dataTypes do
 
-		unitTable = topUnitsData[dataType]
+		local unitTable = topUnitsData[dataType]
 
 		-- sort according to resource usage
 		local sortedTable = {}
 
 		for name, data in unitTable do
-			LOUDINSERT(sortedTable,{name=name, data=data})
+			LOUDINSERT(sortedTable,{name=name, data=math.floor(data)})
 		end
 
 		table.sort(sortedTable, function(a,b) return a.data > b.data end)
@@ -203,7 +203,8 @@ function UpdateResourceUsage()
 
 				for _, unit in unitsWorkedUpon[info.name] do
 
-					if workProgressOnUnit[unit:GetEntityId()] > maxWorkProgress then
+					-- prefer to have any unit at all
+					if unitWithMostProgress == nil or workProgressOnUnit[unit:GetEntityId()] > maxWorkProgress then
 
 						maxWorkProgress = workProgressOnUnit[unit:GetEntityId()]
 						unitWithMostProgress = unit
@@ -225,9 +226,11 @@ function UpdateResourceUsage()
 				button.income:SetText("-" .. info.data)
 
 				-- set the texture that corresponds to the unit
-				local iconName1 = GameCommon.GetUnitIconPath(unitWithMostProgress:GetBlueprint())
+				if unitWithMostProgress != nil then
+					local iconName1 = GameCommon.GetUnitIconPath(unitWithMostProgress:GetBlueprint())
 
-				button.icon:SetTexture(iconName1)
+					button.icon:SetTexture(iconName1)
+				end
 
 				-- show the button
 				button:Show()


### PR DESCRIPTION
Removed all trailing whitespace
Made unnecessary globals into locals
Cached the UpdateScoreData import
Prevented the UI from becoming unreadable by showing fractional amounts of mass/energy usage
Fixed a possible error where unitWithMostProgress may not be set