### PR TITLE
Loud startup error fix

### DIFF
--- a/gamedata/lua/lua/aibrain.lua
+++ b/gamedata/lua/lua/aibrain.lua
@@ -1007,9 +1007,9 @@ AIBrain = Class(moho.aibrain_methods) {
                     -- start the plan
                     ForkThread( import('/lua/ai/aiarchetype-managerloader.lua').ExecutePlan, self )
 
-                    -- Subscribe to ACT if .Adaptive dictates such
-                    import('/lua/loudutilities.lua').SubscribeToACT(self)
                 end
+                -- Subscribe to ACT if .Adaptive dictates such
+                import('/lua/loudutilities.lua').SubscribeToACT(self)
 
             else
 

--- a/gamedata/lua/lua/aibrain.lua
+++ b/gamedata/lua/lua/aibrain.lua
@@ -970,22 +970,56 @@ AIBrain = Class(moho.aibrain_methods) {
 				
 			end
 
-			-- go get and set a plan for MAIN
-			if self:IsOpponentAIRunning() then
 
-				ForkThread( import('/lua/ai/aiarchetype-managerloader.lua').ExecutePlan, self )
+            -- go get and set a plan for MAIN
+            if self:IsOpponentAIRunning() then
+                --If we have active mods that contain custom AIs, then only apply LOUD logic if the name contains LOUD
+                local bCheckForLoud = false
+                local tsLOUDNicknames = {[1] = 'AI: LOUD'}
+                local tExtrasAI = import('/lua/AI/CustomAIs_v2/ExtrasAI.lua').AI.AIList
+                if tExtrasAI then
+                    for iEntry, tAIInfo in tExtrasAI do
+                        if tAIInfo.name and not(tsLOUDNicknames[1] == tAIInfo.name) then table.insert(tsLOUDNicknames, tAIInfo.name) end
+                    end
+                end
 
-                -- Subscribe to ACT if .Adaptive dictates such
-                import('/lua/loudutilities.lua').SubscribeToACT(self)
-			end
-            
-		else
-        
-            -- Civilians are NOT Cheating AI
-            self.CheatingAI = false
-            
+                function IsNicknameALoudNickname(sNickname)
+                    for iEntry, sName in tsLOUDNicknames do
+                        if string.find(self.Nickname, sName) then
+                            return true
+                        end
+                    end
+                    return false
+                end
+                local EnhancedLobby = import('/lua/enhancedlobby.lua')
+                local activeMods = EnhancedLobby.GetActiveMods()
+                if activeMods then
+
+                    for k, mod in activeMods do
+                        local AIFiles = DiskFindFiles(mod.location..'/lua/AI/CustomAIs_v2', '*.lua')
+                        if AIFiles then
+                            bCheckForLoud = true
+                            break
+                        end
+                    end
+                end
+                if not(bCheckForLoud) or not(self.Nickname) or IsNicknameALoudNickname(self.Nickname) then
+                    -- start the plan
+                    ForkThread( import('/lua/ai/aiarchetype-managerloader.lua').ExecutePlan, self )
+
+                    -- Subscribe to ACT if .Adaptive dictates such
+                    import('/lua/loudutilities.lua').SubscribeToACT(self)
+                end
+
+            else
+
+                -- Civilians are NOT Cheating AI
+                self.CheatingAI = false
+
+            end
         end
-        
+
+
     end,
 
 	OnSpawnPreBuiltUnits = function(self)

--- a/gamedata/lua/lua/aibrain.lua
+++ b/gamedata/lua/lua/aibrain.lua
@@ -973,7 +973,6 @@ AIBrain = Class(moho.aibrain_methods) {
 			-- go get and set a plan for MAIN
 			if self:IsOpponentAIRunning() then
 
-				-- start the plan
 				ForkThread( import('/lua/ai/aiarchetype-managerloader.lua').ExecutePlan, self )
 
                 -- Subscribe to ACT if .Adaptive dictates such


### PR DESCRIPTION
If non-LOUD AI are being used, LOUD will still try and running certain logic from the event for the brain creation.  This checks for if there are active mods with custom AI present, and (if so) only runs LOUD related logic if the nickname of the brain contains the name of any of the AI listed in the ExtrasAI.lua LOUD file (currently just AI: LOUD).

Testing on a replay with a custom AI and 2 LOUD AI no desync occurred after making this change, but the error message that would previously show was avoided.

Error message for reference:
warning: Error running lua script: ...e\git-loud\gamedata\lua\lua\ai\aiaddbuildertable.lua(56): attempt to call method `AddBuilder' (a nil value)
         stack traceback:
         	...e\git-loud\gamedata\lua\lua\ai\aiaddbuildertable.lua(56): in function `AddGlobalBuilderGroup'
         	...e\git-loud\gamedata\lua\lua\ai\aiaddbuildertable.lua(80): in function `AddGlobalBaseTemplate'
         	...ud\gamedata\lua\lua\ai\aiarchetype-managerloader.lua(41): in function `SetupMainBase'
         	...ud\gamedata\lua\lua\ai\aiarchetype-managerloader.lua(7): in function <...ud\gamedata\lua\lua\ai\aiarchetype-managerloader.lua:3>