### PR TITLE
Fix lobby AI option refresh bug

### DIFF
--- a/gamedata/lua/lua/ui/lobby/lobby.lua
+++ b/gamedata/lua/lua/ui/lobby/lobby.lua
@@ -302,8 +302,8 @@ local function GetSlotMenuTables(stateKey, hostKey, noais)
     for index, key in slotMenuData[stateKey][hostKey] do
 	
         if key == 'ailist' and not noais then
-		
-            local aitypes = import('/lua/ui/lobby/aitypes.lua').aitypes
+
+            local aitypes = import('/lua/enhancedlobby.lua').GetAIList()
 			
             for aiindex, aidata in aitypes do
                 table.insert(keys, aidata.key)


### PR DESCRIPTION


Fixes a bug with how LOUD refreshes the player/AI options in the lobby - although it attempts to refresh them, it does this with the code:
local aitypes = import('/lua/ui/lobby/aitypes.lua').aitypes

which is defined as:
aitypes = import('/lua/enhancedlobby.lua').GetAIList()

However, this doesnt result in GetAIList() being run each time the first line is called, instead it fetches the result from the time the lobby was originally created.

The proposed code removes the reference to aitypes, meaning it now refreshes (e.g. if a player is removed, or if mod options are changed), meaning if custom AI are used, the list of available custom AI gets refreshed at that point, instead of needing the .exe to be restarted.
