### PR TITLE
Fix lobby option tooltip

### DIFF
--- a/gamedata/lua/lua/ui/dialogs/mapselect.lua
+++ b/gamedata/lua/lua/ui/dialogs/mapselect.lua
@@ -830,11 +830,8 @@ function SetupOptionsPanel(parent, singlePlayer, curOptions)
                     line.combo.keyMap[val.key] = index
 
                     -- tooltip of the combo
-                    if officialOption then 
-                        comboTooltip[index] = 'lob_'..element.data.key..'_'..val.key
-                    else
-                        comboTooltip[index] = { text = val.text, body = val.help }
-                    end
+                    comboTooltip[index] = { text = val.text, body = val.help }
+                    
                 end
 
                 -- we assume the default value of the option is correct here


### PR DESCRIPTION
Custom lobby options added by mods may specify .pref values in tooltips for that option.  It appears that this causes it to be treated as an 'officialOption' resulting in tooltips for drop-down options showing code references, e.g.:
![image](https://github.com/user-attachments/assets/9323de9b-4e86-494d-bced-6635d3f36595)

This remove code causing that, which appears to solve the issue:
![image](https://github.com/user-attachments/assets/3a64bb50-f755-4679-ab82-a8774cfb97d7)

I've checked a few other values in lobby options for errors and can't see anything obvious that looks wrong, but am unsure of the purpose of the original code/if its removal could cause an issue somewhere.