### PR TITLE
Make ahwassa more consistent with dropping bombs

### DIFF
--- a/gamedata/units/units/XSA0402/XSA0402_unit.bp
+++ b/gamedata/units/units/XSA0402/XSA0402_unit.bp
@@ -55,7 +55,7 @@ UnitBlueprint {
 		
         TightTurnMultiplier = 0,
 		
-        TurnSpeed = 0.65,
+        TurnSpeed = 0.9,
 		
         Winged = true,
     },
@@ -253,7 +253,7 @@ UnitBlueprint {
 			
             BallisticArc = 'RULEUBA_None',
 			
-            BombDropThreshold = 4.6,
+            BombDropThreshold = 20,
 			
             CollideFriendly = false,
 			
@@ -276,7 +276,7 @@ UnitBlueprint {
             },
 			
             FiringRandomness = 3,
-            FiringTolerance = 0.36,
+            FiringTolerance = 6,
 			
 			HeadingArcCenter = 0,
 			HeadingArcRange = 14,

--- a/gamedata/units/units/XSA0402/XSA0402_unit.bp
+++ b/gamedata/units/units/XSA0402/XSA0402_unit.bp
@@ -46,8 +46,8 @@ UnitBlueprint {
 		
         LiftFactor = 10.5,
 		
-        MaxAirspeed = 20,
-        MinAirspeed = 18,
+        MaxAirspeed = 18,
+        MinAirspeed = 16,
 		
         PredictAheadForBombDrop = 2.5,
 		
@@ -55,7 +55,7 @@ UnitBlueprint {
 		
         TightTurnMultiplier = 0,
 		
-        TurnSpeed = 0.9,
+        TurnSpeed = 0.7,
 		
         Winged = true,
     },
@@ -247,7 +247,7 @@ UnitBlueprint {
                 Fire = Sound { Bank = 'XSA_Weapon', Cue = 'XSA0402_Strategic_Bomb', LodCutoff = 'Weapon_LodCutoff' },
             },
             
-            AttackGroundTries = 2,
+            AttackGroundTries = 2, --at 2, it often hasnt reloaded before circling around, meaning it ends up aborting the attack and moves on; however at 1 it ends up never firing, so 2 is the 'least worse' option
 			
             AutoInitiateAttackCommand = true,
 			
@@ -276,7 +276,7 @@ UnitBlueprint {
             },
 			
             FiringRandomness = 3,
-            FiringTolerance = 6,
+            FiringTolerance = 2.5,
 			
 			HeadingArcCenter = 0,
 			HeadingArcRange = 14,


### PR DESCRIPTION
Per the discord discussion:
https://discord.com/channels/287858460165406721/412358279960985601/1261985004037345361

In summary, currently the Ahwassa is very inconsistent with dropping bombs.  There are two issues:
-Ground fire targets - even with a massive build up to the target, it fails to drop a bomb in many cases
-Attack orders - it is very inconsistent with whether it fires a bomb.  Part of the issue that makes this far worse is its turn speed means that it can't turn quick enough to be able to fire the bomb at the target, leading to it in some cases repatedly circling a target but never actually firing at it.

The values changed in this pull request are intended as a starting point, but in the 2 replays posted to discord they drastically reduce instances of the ahwassa failing to fire a bomb (when either given a decent lead up to the target, or when left to execute a unit attack order)