### PR TITLE
Brain on death check for nil values

### DIFF
--- a/gamedata/lua/lua/aibrain.lua
+++ b/gamedata/lua/lua/aibrain.lua
@@ -1163,7 +1163,7 @@ AIBrain = Class(moho.aibrain_methods) {
 	
         if self.BuilderManagers then
 		
-            self.ConditionsMonitor:Destroy()
+            if self.ConditionsMonitor then self.ConditionsMonitor:Destroy() end
 			
             for k,v in self.BuilderManagers do
 			
@@ -1242,11 +1242,15 @@ AIBrain = Class(moho.aibrain_methods) {
                 
                 self.CurrentPlan = nil
 				
-				self.ConditionsMonitor.Trash:Destroy()
+				if self.ConditionsMonitor then
+
+					self.ConditionsMonitor.Trash:Destroy()
 				
-				self.ConditionsMonitor:Destroy()
+					self.ConditionsMonitor:Destroy()
 				
-				self.ConditionsMonitor = nil
+					self.ConditionsMonitor = nil
+
+				end
 			
 				for k,v in self.BuilderManagers do
 				
@@ -1349,8 +1353,8 @@ AIBrain = Class(moho.aibrain_methods) {
                 if self.RefuelPool then
                     self:DisbandPlatoon(self.RefuelPool)
                 end
-                
-				self:DisbandPlatoon(self.StructurePool)
+                		
+				if self.StructurePool then self:DisbandPlatoon(self.StructurePool) end
                 
                 if self.TransportPool then
                     self:DisbandPlatoon(self.TransportPool)


### PR DESCRIPTION
Supports the score screen appearing where LOUD wins the game against a custom AI
Currently LOUD assumes that all aibrains will have certain values and tries to call methods such as :Destroy() on them.  This adds checks to see if they are nil first before attempting this (to prevent LOUD erroring out if it wins a game).

Tested with and without the changes to confirm that no score screen prompt appeared without changes, but did appear with changes.