### PR TITLE
Remove obsolete option "GUI: Display Reclaim Window"

### DIFF
--- a/gamedata/lua/lua/options/options.lua
+++ b/gamedata/lua/lua/options/options.lua
@@ -526,18 +526,6 @@ options = {
                 },
             },
             {
-                title = "GUI: Display Reclaim Window",
-                key = 'gui_display_reclaim_totals',
-                type = 'toggle',
-                default = 0,
-                custom = {
-                    states = {
-                        {text = "<LOC _Off>", key = 0 },
-                        {text = "<LOC _On>", key = 1 },
-                    },
-                },
-            },
-            {
                 title = "GUI: Render Custom Names",
                 key = 'gui_render_custom_names',
                 type = 'toggle',

--- a/gamedata/lua/lua/ui/help/tooltips.lua
+++ b/gamedata/lua/lua/ui/help/tooltips.lua
@@ -575,10 +575,6 @@ Tooltips = {
         title = 'Display more Unit Stats',
         description = 'Replaces fuel bar with progress bar, and causes the unitview to always be shown for a 1 unit selection.',
     },
-    options_gui_display_reclaim_totals = {
-        title = 'Display Reclaim Window',
-        description = 'Displays total resources reclaimed all game.',
-    },
     options_gui_render_custom_names = {
         title = 'Render Custom Names',
         description = 'Toggle display of custom names. Enabled by default.',


### PR DESCRIPTION
Since the economy bar has been converted to scalability, the reclaim numbers are a fixed component of the bar. If desired, this part can be made optional again. Until then, this PR removes the currently ignored option `GUI: Display Reclaim Window`.