### PR TITLE
Fix UI layout issues and some code cleanup

### DIFF
--- a/gamedata/lua/lua/maui/grid.lua
+++ b/gamedata/lua/lua/maui/grid.lua
@@ -13,41 +13,40 @@ Grid = Class(Group) {
         self._itemWidth = ScaleNumber(itemWidth)
         self._itemHeight = ScaleNumber(itemHeight)
         self._items = {}
-        self._top = {}
-        self._top["Horz"] = 1
-        self._top["Vert"] = 1
-        self._visible = {}
-        self._lines = {}
-        self._lines["Horz"] = 0
-        self._lines["Vert"] = 0
+        self._top = {
+            ["Horz"] = 1,
+            ["Vert"] = 1
+        }
+        self._lines = {
+            ["Horz"] = 0,
+            ["Vert"] = 0
+        }
         
         -- visible
-        self._visible["Horz"] = LazyVar.Create()
-        self._visible["Vert"] = LazyVar.Create()
-        
+        self._visible = {
+            ["Horz"] = LazyVar.Create(),
+            ["Vert"] = LazyVar.Create()
+        }
+
         self._visible["Horz"]:Set(function() return math.floor(self.Width() / self._itemWidth) end)
         self._visible["Vert"]:Set(function() return math.floor(self.Height() / self._itemHeight) end)
-    
-        -- get frame update to check visibility
-        self:SetNeedsFrameUpdate(true)
-        self._lastVisible = {}
-        self._lastVisible["Horz"] = 0
-        self._lastVisible["Vert"] = 0
-
-    end,
-
-    OnInit = function(self)
-        Control.OnInit(self)
-    end,
-
-    OnFrame = function(self, elapsedTime)
---TODO get rid of this frame function and use the OnDirty of the lazy vars
-        if (self._lastVisible["Horz"] != self._visible["Horz"]()) or
-           (self._lastVisible["Vert"] != self._visible["Vert"]()) then
-            self:_CalculateVisible()
-            self._lastVisible["Horz"] = self._visible["Horz"]()
-            self._lastVisible["Vert"] = self._visible["Vert"]()
+        self._visible["Horz"].OnDirty = function(var)
+            if self._lastVisible["Horz"] ~= var() then
+                self:_CalculateVisible()
+                self._lastVisible["Horz"] = var()
+            end
         end
+        self._visible["Vert"].OnDirty = function(var)
+            if self._lastVisible["Vert"] ~= var() then
+                self:_CalculateVisible()
+                self._lastVisible["Vert"] = var()
+            end
+        end
+
+        self._lastVisible = {
+            ["Horz"] = 0,
+            ["Vert"] = 0
+        }
     end,
 
     _CheckRow = function(self, row)
@@ -57,7 +56,7 @@ Grid = Class(Group) {
         end
         return true
     end,
-    
+
     _CheckCol = function(self, col)
         if (col > self._lines["Horz"]) or (col < 1) then
             error("Grid: Attempt to set column out of range (requested = " .. col .. " range = " .. self._lines["Horz"] .. ")")
@@ -74,6 +73,15 @@ Grid = Class(Group) {
         return self._lines["Horz"], self._lines["Vert"]
     end,
 
+    -- allow changing grid dimensions without need to re-create the whole grid
+    SetDimensions = function(self, itemWidth, itemHeight)
+        self:DeleteAndDestroyAll(true)
+        self._itemWidth = ScaleNumber(itemWidth)
+        self._itemHeight = ScaleNumber(itemHeight)
+        self._visible["Horz"]:Set(function() return math.floor(self.Width() / self._itemWidth) end)
+        self._visible["Vert"]:Set(function() return math.floor(self.Height() / self._itemHeight) end)
+    end,
+
     AppendRows = function(self, count, batch)
         if count < 1 then
             count = 1
@@ -84,7 +92,7 @@ Grid = Class(Group) {
         self._lines["Vert"] = self._lines["Vert"] + count
         if not batch then self:_CalculateVisible() end
     end,
-    
+
     AppendCols = function(self, count, batch)
         if count < 1 then
             count = 1
@@ -92,7 +100,7 @@ Grid = Class(Group) {
         self._lines["Horz"] = self._lines["Horz"] + count
         if not batch then self:_CalculateVisible() end
     end,
-    
+
     DeleteRow = function(self, row, batch)
         if not self:_CheckRow(row) then return end
         for col = 1, self._lines["Horz"] do
@@ -103,11 +111,11 @@ Grid = Class(Group) {
         self._lines["Vert"] = self._lines["Vert"] - 1
         if not batch then self:_CalculateVisible() end
     end,
-    
+
     DeleteCol = function(self, col, batch)
         if not self:_CheckCol(col) then return end
         for row = 1, self._lines["Vert"] do
-            if self._items[row][col] then 
+            if self._items[row][col] then
                 self._items[row][col]:Hide()
                 self._items[row][col] = nil
                 table.remove(self.items[row], col)
@@ -116,7 +124,7 @@ Grid = Class(Group) {
         self._lines["Horz"] = self._lines["Horz"] - 1
         if not batch then self:_CalculateVisible() end
     end,
-    
+
     DeleteAll = function(self, batch)
         for row = 1, self._lines["Vert"] do
             for col = 1, self._lines["Horz"] do
@@ -142,7 +150,7 @@ Grid = Class(Group) {
         self._items[row][col] = control
         if not batch then self:_CalculateVisible() end
     end,
-    
+
     GetItem = function(self, col, row)
         if not self:_CheckRow(row) then return end
         if not self:_CheckCol(col) then return end
@@ -159,7 +167,7 @@ Grid = Class(Group) {
         end
         if not batch then self:_CalculateVisible() end
     end,
-    
+
     RemoveAllItems = function(self, batch)
         for row = 1, self._lines["Vert"] do
             for col = 1, self._lines["Horz"] do
@@ -171,7 +179,7 @@ Grid = Class(Group) {
         self:ScrollSetTop("Vert", 1)
         if not batch then self:_CalculateVisible() end
     end,
-    
+
     -- destroy is useful when the grid has ownership of the items
     DestroyItem = function(self, col, row, batch)
         if not self:_CheckRow(row) then return end
@@ -186,7 +194,7 @@ Grid = Class(Group) {
     DestroyAllItems = function(self, batch)
         for row = 1, self._lines["Vert"] do
             for col = 1, self._lines["Horz"] do
-                if self._items[row][col] then 
+                if self._items[row][col] then
                     self._items[row][col]:Destroy()
                     self._items[row][col] = nil
                 end
@@ -219,7 +227,7 @@ Grid = Class(Group) {
     EndBatch = function(self)
         self:_CalculateVisible()
     end,
-    
+
     GetScrollValues = function(self, axis)
         local rangeMin = 0
         local rangeMax = math.max(self._lines[axis], self._visible[axis]())
@@ -227,22 +235,22 @@ Grid = Class(Group) {
         local visibleMax = (self._top[axis] - 1) + self._visible[axis]()
         return rangeMin, rangeMax, visibleMin, visibleMax
     end,
-    
+
     ScrollLines = function(self, axis, delta)
         self:ScrollSetTop(axis, self._top[axis] + delta)
     end,
-    
+
     ScrollPages = function(self, axis, delta)
         self:ScrollSetTop(axis, self._top[axis] + (delta * self._visible[axis]()))
     end,
-    
+
     ScrollSetTop = function(self, axis, top)
         top = math.floor(top)
         if top == self._top[axis] then return end
         self._top[axis] = math.max(math.min(self._lines[axis] - self._visible[axis]() + 1 , top), 1)
         self:_CalculateVisible()
     end,
-    
+
     IsScrollable = function(self, axis)
         if self._lines[axis] > self._visible[axis]() then
             return true
@@ -256,7 +264,7 @@ Grid = Class(Group) {
         for row = 1, self._lines["Vert"] do
             for col = 1, self._lines["Horz"] do
                 local control = self._items[row][col]
-                if control != nil then
+                if not IsDestroyed(control) then
                     if  (col >= self._top["Horz"]) and (col < self._top["Horz"] + self._visible["Horz"]()) and
                         (row >= self._top["Vert"]) and (row < self._top["Vert"] + self._visible["Vert"]()) then
                         control:SetHidden(false)
@@ -281,4 +289,11 @@ Grid = Class(Group) {
         -- possible to make them not so.
         return not hidden
     end,
+
+    OnDestroy = function(self)
+        self._visible["Horz"]:Destroy()
+        self._visible["Horz"] = nil
+        self._visible["Vert"]:Destroy()
+        self._visible["Vert"] = nil
+    end
 }

--- a/gamedata/lua/lua/maui/layouthelpers.lua
+++ b/gamedata/lua/lua/maui/layouthelpers.lua
@@ -80,7 +80,7 @@ function SetWidth(control, width)
         if type(width) == 'number' then
             control.Width:SetValue(MathFloor(width * pixelScaleFactor))
         else
-            control.Width:Set(width)
+            control.Width:Set(function() return MathFloor(width() * pixelScaleFactor) end)
         end
     end
 end
@@ -93,7 +93,7 @@ function SetHeight(control, height)
         if type(height) == 'number' then
             control.Height:SetValue(MathFloor(height * pixelScaleFactor))
         else
-            control.Height:Set(height)
+            control.Height:Set(function() return MathFloor(height() * pixelScaleFactor) end)
         end
     end
 end

--- a/gamedata/lua/lua/ui/game/layouts/avatars_mini.lua
+++ b/gamedata/lua/lua/ui/game/layouts/avatars_mini.lua
@@ -3,27 +3,27 @@ local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 
 function SetLayout()
     local controls = import('/lua/ui/game/avatars.lua').controls
-    
+
     LayoutHelpers.AtRightTopIn(controls.avatarGroup, controls.parent, 0, 200)
     LayoutHelpers.SetDimensions(controls.avatarGroup, 200, 0)
-    
+
     controls.bgTop:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_t.dds'))
     controls.bgStretch:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_m.dds'))
     controls.bgBottom:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_b.dds'))
-    
+
     LayoutHelpers.AtTopIn(controls.collapseArrow, controls.avatarGroup, 22)
     LayoutHelpers.AtRightIn(controls.collapseArrow, controls.parent, -3)
-    
+
     LayoutHelpers.AtRightIn(controls.bgTop, controls.avatarGroup)
     LayoutHelpers.AtRightIn(controls.bgBottom, controls.avatarGroup)
-    
+
     LayoutHelpers.AnchorToTop(controls.bgTop, controls.avatarGroup, -70)
     controls.bgBottom.Top:Set(function() return math.max(controls.bgTop.Bottom(), controls.avatarGroup.Bottom() + 0) end)
     LayoutHelpers.AnchorToBottom(controls.bgStretch, controls.bgTop)
     LayoutHelpers.AnchorToTop(controls.bgStretch, controls.bgBottom)
     LayoutHelpers.AtRightIn(controls.bgStretch, controls.bgTop, 7)
-    
-    controls.collapseArrow.Depth:Set(function() return controls.bgTop.Depth() + 1 end)
+
+    LayoutHelpers.DepthOverParent(controls.collapseArrow, controls.bgTop)
     controls.collapseArrow:SetTexture(UIUtil.UIFile('/game/tab-r-btn/tab-close_btn_up.dds'))
     controls.collapseArrow:SetNewTextures(UIUtil.UIFile('/game/tab-r-btn/tab-close_btn_up.dds'),
         UIUtil.UIFile('/game/tab-r-btn/tab-open_btn_up.dds'),
@@ -31,15 +31,15 @@ function SetLayout()
         UIUtil.UIFile('/game/tab-r-btn/tab-open_btn_over.dds'),
         UIUtil.UIFile('/game/tab-r-btn/tab-close_btn_dis.dds'),
         UIUtil.UIFile('/game/tab-r-btn/tab-open_btn_dis.dds'))
-        
+
     LayoutAvatars()
 end
 
 function LayoutAvatars()
     local controls = import('/lua/ui/game/avatars.lua').controls
-    
+
     local rightOffset, topOffset, space = 14, 14, -5
-    
+
     local prevControl = false
     local height = 0
     for _, control in controls.avatars do
@@ -76,7 +76,6 @@ function LayoutAvatars()
             height = controls.idleFactories.Height()
         end
     end
-    
+
     controls.avatarGroup.Height:Set(function() return height - LayoutHelpers.ScaleNumber(5) end)
 end
-    

--- a/gamedata/lua/lua/ui/game/layouts/borders_left.lua
+++ b/gamedata/lua/lua/ui/game/layouts/borders_left.lua
@@ -2,7 +2,7 @@ local UIUtil = import('/lua/ui/uiutil.lua')
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 function SetLayout(gameParent)
     local controls = import('/lua/ui/game/borders.lua').controls
-    
+
     controls.bottom:Destroy()
     controls.top:Destroy()
     controls.left:Destroy()
@@ -15,7 +15,7 @@ function SetLayout(gameParent)
     controls.topOS:Destroy()
     controls.leftOS:Destroy()
     controls.rightOS:Destroy()
-    
+
     controls.bottom = false
     controls.top = false
     controls.left = false
@@ -28,45 +28,45 @@ function SetLayout(gameParent)
     controls.topOS = false
     controls.leftOS = false
     controls.rightOS = false
-    
+
     controls.controlClusterGroup.Left:Set(gameParent.Left)
     controls.controlClusterGroup.Bottom:Set(gameParent.Bottom)
-    controls.controlClusterGroup.Top:Set(function() return controls.statusClusterGroup.Bottom() end)
-    controls.controlClusterGroup.Right:Set(function() return gameParent.Left() + 150 end)
-    controls.controlClusterGroup:SetRenderPass(UIUtil.UIRP_PostGlow)    
+    LayoutHelpers.AnchorToBottom(controls.controlClusterGroup, controls.statusClusterGroup)
+    LayoutHelpers.AnchorToLeft(controls.controlClusterGroup, gameParent, -150)
+    controls.controlClusterGroup:SetRenderPass(UIUtil.UIRP_PostGlow)
     controls.controlClusterGroup:DisableHitTest()
-    
+
     controls.statusClusterGroup.Left:Set(gameParent.Left)
     controls.statusClusterGroup.Top:Set(gameParent.Top)
     controls.statusClusterGroup.Right:Set(gameParent.Right)
-    controls.statusClusterGroup.Height:Set(function() return controls.statusClusterGroup.Top() + 150 end)
+    controls.statusClusterGroup.Height:Set(function() return controls.statusClusterGroup.Top() + LayoutHelpers.ScaleNumber(150) end)
     controls.statusClusterGroup:DisableHitTest()
     controls.statusClusterGroup:DisableHitTest()
-    
+
     controls.mapGroup.Left:Set(gameParent.Left)
     controls.mapGroup.Top:Set(gameParent.Top)
     controls.mapGroup.Right:Set(gameParent.Right)
     controls.mapGroup.Bottom:Set(gameParent.Bottom)
     controls.mapGroup:DisableHitTest()
-    
+
     LayoutHelpers.FillParent(controls.windowGroup, gameParent)
     controls.windowGroup:DisableHitTest()
-    
+
     controls.controlClusterGroup:DisableHitTest()
     controls.statusClusterGroup:DisableHitTest()
     controls.mapGroup:DisableHitTest()
-    
+
     if controls.mapGroupLeft then
         controls.mapGroupLeft.Left:Set(gameParent.Left)
         controls.mapGroupLeft.Top:Set(gameParent.Top)
         controls.mapGroupLeft.Right:Set(function() return (gameParent.Left() - 3) + ((gameParent.Right() - gameParent.Left()) / 2) end)
         controls.mapGroupLeft.Bottom:Set(gameParent.Bottom)
-        
+
         controls.mapGroupRight.Left:Set(function() return (gameParent.Left() + 3) + ((gameParent.Right() - gameParent.Left()) / 2) end)
         controls.mapGroupRight.Top:Set(gameParent.Top)
         controls.mapGroupRight.Right:Set(gameParent.Right)
         controls.mapGroupRight.Bottom:Set(gameParent.Bottom)
-        
+
         controls.mapGroup.Left:Set(controls.mapGroupLeft.Left)
         controls.mapGroup.Top:Set(controls.mapGroupLeft.Top)
         controls.mapGroup.Right:Set(controls.mapGroupRight.Right)

--- a/gamedata/lua/lua/ui/game/layouts/borders_mini.lua
+++ b/gamedata/lua/lua/ui/game/layouts/borders_mini.lua
@@ -2,7 +2,7 @@ local UIUtil = import('/lua/ui/uiutil.lua')
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 function SetLayout(gameParent)
     local controls = import('/lua/ui/game/borders.lua').controls
-    
+
     controls.bottom:Destroy()
     controls.top:Destroy()
     controls.left:Destroy()
@@ -15,7 +15,7 @@ function SetLayout(gameParent)
     controls.topOS:Destroy()
     controls.leftOS:Destroy()
     controls.rightOS:Destroy()
-    
+
     controls.bottom = false
     controls.top = false
     controls.left = false
@@ -28,45 +28,45 @@ function SetLayout(gameParent)
     controls.topOS = false
     controls.leftOS = false
     controls.rightOS = false
-    
+
     controls.controlClusterGroup.Left:Set(gameParent.Left)
     controls.controlClusterGroup.Bottom:Set(gameParent.Bottom)
-	controls.controlClusterGroup.Top:Set(function() return controls.controlClusterGroup.Bottom() - LayoutHelpers.ScaleNumber(150) end)
+    LayoutHelpers.AnchorToBottom(controls.controlClusterGroup, controls.controlClusterGroup, -150)
     controls.controlClusterGroup.Right:Set(gameParent.Right)
-    controls.controlClusterGroup:SetRenderPass(UIUtil.UIRP_PostGlow)    
+    controls.controlClusterGroup:SetRenderPass(UIUtil.UIRP_PostGlow)
     controls.controlClusterGroup:DisableHitTest()
-    
+
     controls.statusClusterGroup.Left:Set(gameParent.Left)
     controls.statusClusterGroup.Top:Set(gameParent.Top)
     controls.statusClusterGroup.Right:Set(gameParent.Right)
     controls.statusClusterGroup.Height:Set(function() return controls.statusClusterGroup.Top() + LayoutHelpers.ScaleNumber(150) end)
     controls.statusClusterGroup:DisableHitTest()
     controls.statusClusterGroup:DisableHitTest()
-    
+
     controls.mapGroup.Left:Set(gameParent.Left)
     controls.mapGroup.Top:Set(gameParent.Top)
     controls.mapGroup.Right:Set(gameParent.Right)
     controls.mapGroup.Bottom:Set(gameParent.Bottom)
     controls.mapGroup:DisableHitTest()
-    
+
     LayoutHelpers.FillParent(controls.windowGroup, gameParent)
     controls.windowGroup:DisableHitTest()
-    
+
     controls.controlClusterGroup:DisableHitTest()
     controls.statusClusterGroup:DisableHitTest()
     controls.mapGroup:DisableHitTest()
-    
+
     if controls.mapGroupLeft then
         controls.mapGroupLeft.Left:Set(gameParent.Left)
         controls.mapGroupLeft.Top:Set(gameParent.Top)
         controls.mapGroupLeft.Right:Set(function() return (gameParent.Left() - LayoutHelpers.ScaleNumber(3)) + ((gameParent.Right() - gameParent.Left()) / 2) end)
         controls.mapGroupLeft.Bottom:Set(gameParent.Bottom)
-        
+
         controls.mapGroupRight.Left:Set(function() return (gameParent.Left() + LayoutHelpers.ScaleNumber(3)) + ((gameParent.Right() - gameParent.Left()) / 2) end)
         controls.mapGroupRight.Top:Set(gameParent.Top)
         controls.mapGroupRight.Right:Set(gameParent.Right)
         controls.mapGroupRight.Bottom:Set(gameParent.Bottom)
-        
+
         controls.mapGroup.Left:Set(controls.mapGroupLeft.Left)
         controls.mapGroup.Top:Set(controls.mapGroupLeft.Top)
         controls.mapGroup.Right:Set(controls.mapGroupRight.Right)

--- a/gamedata/lua/lua/ui/game/layouts/construction_left.lua
+++ b/gamedata/lua/lua/ui/game/layouts/construction_left.lua
@@ -47,43 +47,44 @@ function SetLayout()
     local ordersControl = import('/lua/ui/game/construction.lua').ordersControl
     local controlClusterGroup = import('/lua/ui/game/construction.lua').controlClusterGroup
     controls.constructionGroup.Left:Set(controlClusterGroup.Left)
-    controls.constructionGroup.Bottom:Set(function() return controlClusterGroup.Bottom() - 5 end)
+    LayoutHelpers.AtBottomIn(controls.constructionGroup, controlClusterGroup, 5)
     if ordersControl then
-        controls.constructionGroup.Top:Set(function() return ordersControl.Bottom() + 2 end)
+        LayoutHelpers.AnchorToBottom(controls.constructionGroup, ordersControl, 2)
     else
-        controls.constructionGroup.Top:Set(function() return controlClusterGroup.Top() + 2 end)
+        LayoutHelpers.AtTopIn(controls.constructionGroup, controlClusterGroup, 2)
     end
     controls.constructionGroup.Right:Set(controlClusterGroup.Right)
-    
+
     controls.minBG:SetTexture(UIUtil.UIFile('/game/construct-panel_vert/construct-panel_bmp_t.dds'))
     LayoutHelpers.AtTopIn(controls.minBG, controls.constructionGroup, 36)
     LayoutHelpers.AtLeftIn(controls.minBG, controls.constructionGroup, 21)
     LayoutHelpers.ResetRight(controls.minBG)
     LayoutHelpers.ResetBottom(controls.minBG)
-    
+    LayoutHelpers.SetDimensions(controls.minBG, controls.minBG.BitmapWidth, controls.minBG.BitmapHeight)
+
     controls.leftBracketMin:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_t.dds'))
     controls.leftBracketMin.Left:Set(controls.constructionGroup.Left)
-    controls.leftBracketMin.Top:Set(function() return controls.constructionGroup.Top() + 1 end)
-    
+    LayoutHelpers.AtTopIn(controls.leftBracketMin, controls.constructionGroup, 1)
+
     controls.leftBracketMax:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_b.dds'))
     controls.leftBracketMax.Left:Set(controls.constructionGroup.Left)
-    controls.leftBracketMax.Bottom:Set(function() return controls.constructionGroup.Bottom() + 4 end)
-    
+    LayoutHelpers.AtBottomIn(controls.leftBracketMax, controls.constructionGroup, -4)
+
     controls.leftBracketMid:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_m.dds'))
-    controls.leftBracketMid.Left:Set(function() return controls.constructionGroup.Left() + 7 end)
+    LayoutHelpers.AtLeftIn(controls.leftBracketMid, controls.constructionGroup, 7)
     controls.leftBracketMid.Bottom:Set(controls.leftBracketMax.Top)
     controls.leftBracketMid.Top:Set(controls.leftBracketMin.Bottom)
-    
+
     controls.rightBracketMin:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_t.dds'))
-    controls.rightBracketMin.Right:Set(function() return controls.minBG.Right() + 11 end)
-    controls.rightBracketMin.Top:Set(function() return controls.constructionGroup.Top() + 6 end)
-    
+    LayoutHelpers.AtRightIn(controls.rightBracketMin, controls.minBG, -11)
+    LayoutHelpers.AtTopIn(controls.rightBracketMin, controls.constructionGroup, 6)
+
     controls.rightBracketMax:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_b.dds'))
-    controls.rightBracketMax.Right:Set(function() return controls.minBG.Right() + 11 end)
-    controls.rightBracketMax.Bottom:Set(function() return controls.constructionGroup.Bottom() + 1 end)
-    
+    LayoutHelpers.AtRightIn(controls.rightBracketMax, controls.minBG, -11)
+    LayoutHelpers.AtBottomIn(controls.rightBracketMax, controls.constructionGroup, -1)
+
     controls.rightBracketMid:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_m.dds'))
-    controls.rightBracketMid.Right:Set(function() return controls.minBG.Right() + 11 end)
+    LayoutHelpers.AtRightIn(controls.rightBracketMid, controls.minBG, -11)
     controls.rightBracketMid.Bottom:Set(controls.rightBracketMax.Top)
     controls.rightBracketMid.Top:Set(controls.rightBracketMin.Bottom)
 
@@ -101,24 +102,23 @@ function SetLayout()
         controls.midBG2:Destroy()
         controls.midBG2 = false
     end
-    
+
     controls.midBG3:SetTexture(UIUtil.UIFile('/game/construct-panel_vert/construct-panel_bmp_m.dds'))
     controls.midBG3.Left:Set(controls.minBG.Left)
     controls.midBG3.Top:Set(controls.minBG.Bottom)
     controls.midBG3.Bottom:Set(controls.maxBG.Top)
-    controls.midBG3.Width:Set(controls.midBG3.BitmapWidth)
-    controls.midBG3:SetTiled(true)
+    LayoutHelpers.SetWidth(controls.midBG3, controls.midBG3.BitmapWidth)
     LayoutHelpers.ResetRight(controls.midBG3)
     LayoutHelpers.ResetHeight(controls.midBG3)
-    
-    controls.choices.Top:Set(function() return controls.constructionGroup.Top() + 100 end)
-    controls.choices.Bottom:Set(function() return controls.constructionGroup.Bottom() - 38 end)
-    controls.choices.Left:Set(function() return controls.minBG.Left() + 10 end)
-    controls.choices.Width:Set(56)
+
+    LayoutHelpers.AtTopIn(controls.choices, controls.constructionGroup, 100)
+    LayoutHelpers.AtBottomIn(controls.choices, controls.constructionGroup, 38)
+    LayoutHelpers.AtLeftIn(controls.choices, controls.minBG, 10)
+    LayoutHelpers.SetWidth(controls.choices, 56)
     controls.choices:SetToVertical(true)
     LayoutHelpers.ResetHeight(controls.choices)
     LayoutHelpers.ResetRight(controls.choices)
-    
+
     controls.choicesBGMin:SetTexture(UIUtil.UIFile('/game/construct-panel_vert/que-panel_bmp_t.dds'))
     LayoutHelpers.AtLeftTopIn(controls.choicesBGMin, controls.choices, 1, -30)
     controls.choicesBGMax:SetTexture(UIUtil.UIFile('/game/construct-panel_vert/que-panel_bmp_b.dds'))
@@ -131,18 +131,18 @@ function SetLayout()
     controls.choicesBGMid.Top:Set(controls.choicesBGMin.Bottom)
     controls.choicesBGMid.Bottom:Set(controls.choicesBGMax.Top)
     LayoutHelpers.ResetRight(controls.choicesBGMid)
-    
+
     controls.choicesBGMax.Depth:Set(function() return controls.choices.Depth() - 2 end)
     controls.choicesBGMid.Depth:Set(function() return controls.choices.Depth() - 2 end)
     controls.choicesBGMin.Depth:Set(function() return controls.choices.Depth() - 2 end)
-    
+
     controls.scrollMin:SetNewTextures(textures.midBtn.up, textures.midBtn.down, textures.midBtn.over, textures.midBtn.dis)
     controls.scrollMin:SetTexture(textures.midBtn.up)
     LayoutHelpers.Above(controls.scrollMin, controls.choices, 2)
     LayoutHelpers.AtLeftIn(controls.scrollMin, controls.choices, -1)
     LayoutHelpers.ResetRight(controls.scrollMin)
     LayoutHelpers.ResetTop(controls.scrollMin)
-    
+
     controls.scrollMinIcon:SetTexture(textures.minIcon.on)
     LayoutHelpers.AtCenterIn(controls.scrollMinIcon, controls.scrollMin)
     controls.scrollMinIcon:DisableHitTest()
@@ -154,13 +154,13 @@ function SetLayout()
         controls.scrollMinIcon:SetTexture(textures.minIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.scrollMax:SetNewTextures(textures.midBtn.up, textures.midBtn.down, textures.midBtn.over, textures.midBtn.dis)
     controls.scrollMax:SetTexture(textures.midBtn.up)
     LayoutHelpers.Above(controls.scrollMax, controls.pageMax, 1)
     LayoutHelpers.ResetRight(controls.scrollMax)
     LayoutHelpers.ResetTop(controls.scrollMax)
-    
+
     controls.scrollMaxIcon:SetTexture(textures.maxIcon.on)
     LayoutHelpers.AtCenterIn(controls.scrollMaxIcon, controls.scrollMax)
     controls.scrollMaxIcon:DisableHitTest()
@@ -172,13 +172,13 @@ function SetLayout()
         controls.scrollMaxIcon:SetTexture(textures.maxIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.pageMin:SetNewTextures(textures.minBtn.up, textures.minBtn.down, textures.minBtn.over, textures.minBtn.dis)
     controls.pageMin:SetTexture(textures.minBtn.up)
     LayoutHelpers.Above(controls.pageMin, controls.scrollMin, 1)
     LayoutHelpers.ResetRight(controls.pageMin)
     LayoutHelpers.ResetTop(controls.pageMin)
-    
+
     controls.pageMinIcon:SetTexture(textures.pageMinIcon.on)
     LayoutHelpers.AtCenterIn(controls.pageMinIcon, controls.pageMin)
     controls.pageMinIcon:DisableHitTest()
@@ -190,15 +190,15 @@ function SetLayout()
         controls.pageMinIcon:SetTexture(textures.pageMinIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.pageMax:SetNewTextures(textures.maxBtn.up, textures.maxBtn.down, textures.maxBtn.over, textures.maxBtn.dis)
     controls.pageMax:SetTexture(textures.maxBtn.up)
     LayoutHelpers.AtBottomIn(controls.pageMax, controls.choicesBGMax, -1)
     LayoutHelpers.AtLeftIn(controls.pageMax, controls.choicesBGMax, -1)
     LayoutHelpers.ResetRight(controls.pageMax)
     LayoutHelpers.ResetTop(controls.pageMax)
-    
-    
+
+
     controls.pageMaxIcon:SetTexture(textures.pageMaxIcon.on)
     LayoutHelpers.AtCenterIn(controls.pageMaxIcon, controls.pageMax)
     controls.pageMaxIcon:DisableHitTest()
@@ -210,13 +210,13 @@ function SetLayout()
         controls.pageMaxIcon:SetTexture(textures.pageMaxIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.secondaryChoices.Top:Set(controls.choices.Top)
     controls.secondaryChoices.Bottom:Set(controls.choices.Bottom)
-    controls.secondaryChoices.Left:Set(function() return controls.choices.Right() + 4 end)
-    controls.secondaryChoices.Right:Set(function() return controls.secondaryChoices.Left() + 56 end)
+    LayoutHelpers.AnchorToRight(controls.secondaryChoices, controls.choices, 4)
+    LayoutHelpers.AnchorToLeft(controls.secondaryChoices, controls.secondaryChoices, -56)
     controls.secondaryChoices:SetToVertical(true)
-    
+
     controls.secondaryChoicesBGMin:SetTexture(UIUtil.UIFile('/game/construct-panel_vert/que-panel_bmp_t.dds'))
     LayoutHelpers.AtLeftTopIn(controls.secondaryChoicesBGMin, controls.secondaryChoices, 1, -30)
     controls.secondaryChoicesBGMax:SetTexture(UIUtil.UIFile('/game/construct-panel_vert/que-panel_bmp_b.dds'))
@@ -229,25 +229,24 @@ function SetLayout()
     controls.secondaryChoicesBGMid.Top:Set(controls.secondaryChoicesBGMin.Bottom)
     controls.secondaryChoicesBGMid.Bottom:Set(controls.secondaryChoicesBGMax.Top)
     LayoutHelpers.ResetRight(controls.secondaryChoicesBGMid)
-    
+
     controls.secondaryChoicesBGMin.Depth:Set(function() return controls.secondaryChoices.Depth() - 1 end)
     controls.secondaryChoicesBGMax.Depth:Set(function() return controls.secondaryChoices.Depth() - 1 end)
     controls.secondaryChoicesBGMid.Depth:Set(function() return controls.secondaryChoices.Depth() - 1 end)
-    
+
     LayoutHelpers.AtLeftIn(controls.secondaryProgress, controls.secondaryChoices, 8)
     LayoutHelpers.AtTopIn(controls.secondaryProgress, controls.secondaryChoices, 42)
     LayoutHelpers.ResetBottom(controls.secondaryProgress)
     controls.secondaryProgress.Depth:Set(function() return controls.secondaryChoices.Depth() + 5 end)
-    controls.secondaryProgress.Width:Set(40)
-    controls.secondaryProgress.Height:Set(4)
-    
+    LayoutHelpers.SetDimensions(controls.secondaryProgress, 40, 4)
+
     controls.secondaryScrollMin:SetNewTextures(textures.midBtn.up, textures.midBtn.down, textures.midBtn.over, textures.midBtn.dis)
     controls.secondaryScrollMin:SetTexture(textures.midBtn.up)
     LayoutHelpers.Above(controls.secondaryScrollMin, controls.secondaryChoices, 2)
     LayoutHelpers.AtLeftIn(controls.secondaryScrollMin, controls.secondaryChoices, -1)
     LayoutHelpers.ResetRight(controls.secondaryScrollMin)
     LayoutHelpers.ResetTop(controls.secondaryScrollMin)
-    
+
     controls.secondaryScrollMinIcon:SetTexture(textures.minIcon.on)
     LayoutHelpers.AtCenterIn(controls.secondaryScrollMinIcon, controls.secondaryScrollMin)
     controls.secondaryScrollMinIcon:DisableHitTest()
@@ -259,13 +258,13 @@ function SetLayout()
         controls.secondaryScrollMinIcon:SetTexture(textures.minIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.secondaryScrollMax:SetNewTextures(textures.midBtn.up, textures.midBtn.down, textures.midBtn.over, textures.midBtn.dis)
     controls.secondaryScrollMax:SetTexture(textures.midBtn.up)
     LayoutHelpers.Above(controls.secondaryScrollMax, controls.secondaryPageMax, 1)
     LayoutHelpers.ResetRight(controls.secondaryScrollMax)
     LayoutHelpers.ResetTop(controls.secondaryScrollMax)
-    
+
     controls.secondaryScrollMaxIcon:SetTexture(textures.maxIcon.on)
     LayoutHelpers.AtCenterIn(controls.secondaryScrollMaxIcon, controls.secondaryScrollMax)
     controls.secondaryScrollMaxIcon:DisableHitTest()
@@ -277,13 +276,13 @@ function SetLayout()
         controls.secondaryScrollMaxIcon:SetTexture(textures.maxIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.secondaryPageMin:SetNewTextures(textures.minBtn.up, textures.minBtn.down, textures.minBtn.over, textures.minBtn.dis)
     controls.secondaryPageMin:SetTexture(textures.minBtn.up)
     LayoutHelpers.Above(controls.secondaryPageMin, controls.secondaryScrollMin, 1)
     LayoutHelpers.ResetRight(controls.secondaryPageMin)
     LayoutHelpers.ResetTop(controls.secondaryPageMin)
-    
+
     controls.secondaryPageMinIcon:SetTexture(textures.pageMinIcon.on)
     LayoutHelpers.AtCenterIn(controls.secondaryPageMinIcon, controls.secondaryPageMin)
     controls.secondaryPageMinIcon:DisableHitTest()
@@ -295,14 +294,14 @@ function SetLayout()
         controls.secondaryPageMinIcon:SetTexture(textures.pageMinIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.secondaryPageMax:SetNewTextures(textures.maxBtn.up, textures.maxBtn.down, textures.maxBtn.over, textures.maxBtn.dis)
     controls.secondaryPageMax:SetTexture(textures.maxBtn.up)
     LayoutHelpers.AtBottomIn(controls.secondaryPageMax, controls.secondaryChoicesBGMax, -1)
     LayoutHelpers.AtLeftIn(controls.secondaryPageMax, controls.secondaryChoicesBGMax, -1)
     LayoutHelpers.ResetRight(controls.secondaryPageMax)
     LayoutHelpers.ResetTop(controls.secondaryPageMax)
-    
+
     controls.secondaryPageMaxIcon:SetTexture(textures.pageMaxIcon.on)
     LayoutHelpers.AtCenterIn(controls.secondaryPageMaxIcon, controls.secondaryPageMax)
     controls.secondaryPageMaxIcon:DisableHitTest()
@@ -314,14 +313,14 @@ function SetLayout()
         controls.secondaryPageMaxIcon:SetTexture(textures.pageMaxIcon.on)
         Button.OnEnable(self)
     end
-    
-    controls.extraBtn1:SetNewTextures(UIUtil.UIFile('/game/construct-sm_horiz_btn/que_btn_up.dds'), 
+
+    controls.extraBtn1:SetNewTextures(UIUtil.UIFile('/game/construct-sm_horiz_btn/que_btn_up.dds'),
         UIUtil.UIFile('/game/construct-sm_horiz_btn/que_btn_selected.dds'),
         UIUtil.UIFile('/game/construct-sm_horiz_btn/que_btn_over.dds'),
         UIUtil.UIFile('/game/construct-sm_horiz_btn/que_btn_over.dds'),
         UIUtil.UIFile('/game/construct-sm_horiz_btn/que_btn_dis.dds'),
         UIUtil.UIFile('/game/construct-sm_horiz_btn/que_btn_dis.dds'))
-    controls.extraBtn2:SetNewTextures(UIUtil.UIFile('/game/construct-sm_horiz_btn/que_btn_up.dds'), 
+    controls.extraBtn2:SetNewTextures(UIUtil.UIFile('/game/construct-sm_horiz_btn/que_btn_up.dds'),
         UIUtil.UIFile('/game/construct-sm_horiz_btn/que_btn_selected.dds'),
         UIUtil.UIFile('/game/construct-sm_horiz_btn/que_btn_over.dds'),
         UIUtil.UIFile('/game/construct-sm_horiz_btn/que_btn_over.dds'),
@@ -329,7 +328,7 @@ function SetLayout()
         UIUtil.UIFile('/game/construct-sm_horiz_btn/que_btn_dis.dds'))
     LayoutHelpers.AtLeftTopIn(controls.extraBtn1, controls.minBG, 9, 5)
     LayoutHelpers.RightOf(controls.extraBtn2, controls.extraBtn1, 3)
-    
+
     controls.constructionGroup:DisableHitTest()
     LayoutTabs(import('/lua/ui/game/construction.lua').controls)
     controls.constructionGroup:Hide()
@@ -337,7 +336,7 @@ end
 
 function LayoutTabs(controls)
     local prevControl = false
-    
+
     local tabFiles = {
         construction = '/game/construct-tab_top_btn/top_tab_btn_',
         selection = '/game/construct-tab_top_btn/mid_tab_btn_',
@@ -352,56 +351,56 @@ function LayoutTabs(controls)
         LCH = '/game/construct-tech_btn/left_upgrade_btn_',
         RCH = '/game/construct-tech_btn/r_upgrade_btn_',
         Back = '/game/construct-tech_btn/m_upgrade_btn_',
+        Command = '/game/construct-tech_btn/left_upgrade_btn_',
     }
-    
+
     local function GetTabTextures(id)
         if tabFiles[id] then
             local pre = tabFiles[id]
             return UIUtil.UIFile(pre..'up_bmp.dds'), UIUtil.UIFile(pre..'sel_bmp.dds'),
-                UIUtil.UIFile(pre..'over_bmp.dds'), UIUtil.UIFile(pre..'down_bmp.dds'), 
+                UIUtil.UIFile(pre..'over_bmp.dds'), UIUtil.UIFile(pre..'down_bmp.dds'),
                 UIUtil.UIFile(pre..'dis_bmp.dds'), UIUtil.UIFile(pre..'dis_bmp.dds')
         elseif techFiles[id] then
             local pre = techFiles[id]
             return UIUtil.UIFile(pre..'up.dds'), UIUtil.UIFile(pre..'selected.dds'),
-                UIUtil.UIFile(pre..'over.dds'), UIUtil.UIFile(pre..'down.dds'), 
+                UIUtil.UIFile(pre..'over.dds'), UIUtil.UIFile(pre..'down.dds'),
                 UIUtil.UIFile(pre..'dis.dds'), UIUtil.UIFile(pre..'dis.dds')
         end
     end
-    
+
     local function SetupTab(control)
         control:SetNewTextures(GetTabTextures(control.ID))
         control:UseAlphaHitTest(false)
-               
+
         control.OnDisable = function(self)
             self.disabledGroup:Enable()
             Checkbox.OnDisable(self)
         end
-        
-        control.disabledGroup.Height:Set(25)
-        control.disabledGroup.Width:Set(40)
+
+        LayoutHelpers.SetDimensions(control.disabledGroup, 40, 25)
         LayoutHelpers.AtCenterIn(control.disabledGroup, control)
-        
+
         control.OnEnable = function(self)
             self.disabledGroup:Disable()
             Checkbox.OnEnable(self)
         end
     end
-    
+
     if table.getsize(controls.tabs) > 0 then
         for id, control in controls.tabs do
             SetupTab(control)
-             
+
             if not prevControl then
                 LayoutHelpers.AtLeftTopIn(control, controls.minBG, 134, 60)
             else
                 local offset = 0
                 LayoutHelpers.Below(control, prevControl, offset)
             end
-            
+
             prevControl = control
         end
     end
-    
+
     SetupTab(controls.constructionTab)
     LayoutHelpers.AtLeftTopIn(controls.constructionTab, controls.constructionGroup, 20, 7)
     SetupTab(controls.selectionTab)
@@ -413,6 +412,7 @@ end
 function OnTabChangeLayout(type)
     local controls = import('/lua/ui/game/construction.lua').controls
     if type == 'construction' or type == 'templates' then
+        controls.extraBtn1.icon:Show()
         controls.extraBtn1.icon.OnTexture = UIUtil.UIFile('/game/construct-sm_btn/infinite_on.dds')
         controls.extraBtn1.icon.OffTexture = UIUtil.UIFile('/game/construct-sm_btn/infinite_off.dds')
         if controls.extraBtn1:IsDisabled() then
@@ -428,8 +428,9 @@ function OnTabChangeLayout(type)
         else
             controls.extraBtn2.icon:SetTexture(controls.extraBtn2.icon.OnTexture)
         end
-        
+
     elseif type == 'selection' then
+        controls.extraBtn1.icon:Show()
         controls.extraBtn1.icon.OnTexture = UIUtil.UIFile('/game/construct-sm_btn/template_on.dds')
         controls.extraBtn1.icon.OffTexture = UIUtil.UIFile('/game/construct-sm_btn/template_off.dds')
         if controls.extraBtn1:IsDisabled() then

--- a/gamedata/lua/lua/ui/game/layouts/construction_mini.lua
+++ b/gamedata/lua/lua/ui/game/layouts/construction_mini.lua
@@ -55,42 +55,40 @@ function SetLayout()
         controls.constructionGroup.Left:Set(controlClusterGroup.Left)
     end
     LayoutHelpers.AtRightIn(controls.constructionGroup, controlClusterGroup, 18)
-    
+
     controls.minBG:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_l.dds'))
     LayoutHelpers.AtBottomIn(controls.minBG, controls.constructionGroup, 4)
     LayoutHelpers.AtLeftIn(controls.minBG, controls.constructionGroup, 67)
     LayoutHelpers.ResetRight(controls.minBG)
     LayoutHelpers.ResetTop(controls.minBG)
-    LayoutHelpers.SetDimensions(controls.minBG, controls.minBG.BitmapWidth(), controls.minBG.BitmapHeight()) -- TODO: This is now set value instead of a function to get Bitmap dimension. When when the texture changes, it wont properly resize anymore
-    --controls.minBG.Width:Set(controls.minBG.BitmapWidth)
-    --controls.minBG.Height:Set(controls.minBG.BitmapHeight)
-    
+    LayoutHelpers.SetDimensions(controls.minBG, controls.minBG.BitmapWidth, controls.minBG.BitmapHeight)
+
     controls.leftBracketMin:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_t.dds'))
     LayoutHelpers.AtLeftIn(controls.leftBracketMin, controls.constructionGroup, 4)
     LayoutHelpers.AtTopIn(controls.leftBracketMin, controls.constructionGroup, 21)
-    
+
     controls.leftBracketMax:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_b.dds'))
-    LayoutHelpers.AtLeftIn(controls.leftBracketMax, controls.leftBracketMin)
+    controls.leftBracketMax.Left:Set(controls.leftBracketMin.Left)
     LayoutHelpers.AtBottomIn(controls.leftBracketMax, controls.constructionGroup, 2)
-    
+
     controls.leftBracketMid:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_m.dds'))
-    LayoutHelpers.AtLeftIn(controls.leftBracketMid, controls.leftBracketMin)
+    controls.leftBracketMid.Left:Set(controls.leftBracketMin.Left)
     controls.leftBracketMid.Bottom:Set(controls.leftBracketMax.Top)
     controls.leftBracketMid.Top:Set(controls.leftBracketMin.Bottom)
-    
+
     controls.rightBracketMin:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_t.dds'))
     LayoutHelpers.AtRightIn(controls.rightBracketMin, controls.maxBG, -21)
     LayoutHelpers.AtTopIn(controls.rightBracketMin, controls.maxBG, -6)
-    
+
     controls.rightBracketMax:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_b.dds'))
     LayoutHelpers.AtRightIn(controls.rightBracketMax, controls.maxBG, -21)
     LayoutHelpers.AtBottomIn(controls.rightBracketMax, controls.maxBG, -5)
-    
+
     controls.rightBracketMid:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_m.dds'))
     LayoutHelpers.AtRightIn(controls.rightBracketMid, controls.maxBG, -14)
     controls.rightBracketMid.Bottom:Set(controls.rightBracketMax.Top)
     controls.rightBracketMid.Top:Set(controls.rightBracketMin.Bottom)
-    
+
     controls.maxBG:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_r.dds'))
     LayoutHelpers.AtBottomIn(controls.maxBG, controls.minBG, 1)
     LayoutHelpers.AtRightIn(controls.maxBG, controls.constructionGroup, 2)
@@ -103,34 +101,27 @@ function SetLayout()
     controls.midBG1:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_m1.dds'))
     controls.midBG1.Left:Set(controls.minBG.Right)
     controls.midBG1.Bottom:Set(controls.minBG.Bottom)
-    LayoutHelpers.SetDimensions(controls.midBG1, controls.midBG1.BitmapWidth(), controls.midBG1.BitmapHeight())-- TODO: Same scaling issue as the first one
-    --controls.midBG1.Height:Set(controls.midBG1.BitmapHeight)
-    --controls.midBG1.Width:Set(controls.midBG1.BitmapWidth)
+    LayoutHelpers.SetDimensions(controls.midBG1, controls.midBG1.BitmapWidth, controls.midBG1.BitmapHeight)
     LayoutHelpers.ResetTop(controls.midBG1)
-    
+
     if not controls.midBG2 then
         controls.midBG2 = Bitmap(controls.constructionGroup)
     end
     controls.midBG2:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_m2.dds'))
     controls.midBG2.Left:Set(controls.midBG1.Right)
     controls.midBG2.Bottom:Set(controls.minBG.Bottom)
-    LayoutHelpers.SetDimensions(controls.midBG2, controls.midBG2.BitmapWidth(), controls.midBG2.BitmapHeight())-- TODO: Same scaling issue as the first one
-    --controls.midBG2.Height:Set(controls.midBG2.BitmapHeight)
-    --controls.midBG2.Width:Set(controls.midBG2.BitmapWidth)
+    LayoutHelpers.SetDimensions(controls.midBG2, controls.midBG2.BitmapWidth, controls.midBG2.BitmapHeight)
     LayoutHelpers.ResetTop(controls.midBG2)
-    
+
     controls.midBG3:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_m3.dds'))
     controls.midBG3.Left:Set(controls.midBG2.Right)
     controls.midBG3.Right:Set(controls.maxBG.Left)
     controls.midBG3.Bottom:Set(controls.maxBG.Bottom)
-    --controls.midBG3:SetTiled(true) -- TODO: Find out what this does, with true the line isnt set properly
-    LayoutHelpers.SetHeight(controls.midBG3, controls.midBG3.BitmapHeight())-- TODO: Same scaling issue as the first one
-    --controls.midBG3.Height:Set(controls.midBG3.BitmapHeight)
+    LayoutHelpers.SetHeight(controls.midBG3, controls.midBG3.BitmapHeight)
     LayoutHelpers.ResetWidth(controls.midBG3)
     LayoutHelpers.ResetTop(controls.midBG3)
-    LayoutHelpers.SetHeight(controls.midBG3, controls.midBG3.BitmapHeight())-- TODO: Same scaling issue as the first one
-    --controls.midBG3.Height:Set(controls.midBG3.BitmapHeight)
-    
+    LayoutHelpers.SetHeight(controls.midBG3, controls.midBG3.BitmapHeight)
+
     LayoutHelpers.AtTopIn(controls.choices, controls.minBG, 5)
     LayoutHelpers.SetHeight(controls.choices, 50)
     controls.choices:SetToVertical(false)
@@ -138,7 +129,7 @@ function SetLayout()
     LayoutHelpers.AtRightIn(controls.choices, controls.maxBG, 25)
     LayoutHelpers.ResetWidth(controls.choices)
     LayoutHelpers.ResetBottom(controls.choices)
-    
+
     controls.choicesBGMin:SetTexture(UIUtil.UIFile('/game/construct-panel/que-panel_bmp_l.dds'))
     LayoutHelpers.AtLeftTopIn(controls.choicesBGMin, controls.choices, -46)
     controls.choicesBGMax:SetTexture(UIUtil.UIFile('/game/construct-panel/que-panel_bmp_r.dds'))
@@ -150,21 +141,19 @@ function SetLayout()
     LayoutHelpers.ResetBottom(controls.choicesBGMid)
     controls.choicesBGMid.Left:Set(controls.choicesBGMin.Right)
     controls.choicesBGMid.Right:Set(controls.choicesBGMax.Left)
-    
+
     controls.choicesBGMax.Depth:Set(function() return controls.choices.Depth() - 1 end)
     controls.choicesBGMid.Depth:Set(function() return controls.choices.Depth() - 1 end)
     controls.choicesBGMin.Depth:Set(function() return controls.choices.Depth() - 1 end)
-    
+
     controls.scrollMin:SetNewTextures(textures.midBtn.up, textures.midBtn.down, textures.midBtn.over, textures.midBtn.dis)
     controls.scrollMin:SetTexture(textures.midBtn.up)
     LayoutHelpers.AnchorToLeft(controls.scrollMin, controls.choices, 4)
     LayoutHelpers.AtVerticalCenterIn(controls.scrollMin, controls.choices)
     LayoutHelpers.ResetLeft(controls.scrollMin)
     LayoutHelpers.ResetBottom(controls.scrollMin)
-    LayoutHelpers.SetDimensions(controls.scrollMin, controls.scrollMin.BitmapWidth(), controls.scrollMin.BitmapHeight())-- TODO: Same scaling issue as the first one
-    --controls.scrollMin.Height:Set(controls.scrollMin.BitmapHeight)
-    --controls.scrollMin.Width:Set(controls.scrollMin.BitmapWidth)
-    
+    LayoutHelpers.SetDimensions(controls.scrollMin, controls.scrollMin.BitmapWidth, controls.scrollMin.BitmapHeight)
+
     controls.scrollMinIcon:SetTexture(textures.minIcon.on)
     LayoutHelpers.AtCenterIn(controls.scrollMinIcon, controls.scrollMin)
     controls.scrollMinIcon:DisableHitTest()
@@ -176,14 +165,14 @@ function SetLayout()
         controls.scrollMinIcon:SetTexture(textures.minIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.scrollMax:SetNewTextures(textures.midBtn.up, textures.midBtn.down, textures.midBtn.over, textures.midBtn.dis)
     controls.scrollMax:SetTexture(textures.midBtn.up)
     controls.scrollMax.Left:Set(controls.choices.Right)
     LayoutHelpers.AtVerticalCenterIn(controls.scrollMax, controls.choices)
     LayoutHelpers.ResetRight(controls.scrollMax)
     LayoutHelpers.ResetBottom(controls.scrollMax)
-    
+
     controls.scrollMaxIcon:SetTexture(textures.maxIcon.on)
     LayoutHelpers.AtCenterIn(controls.scrollMaxIcon, controls.scrollMax)
     controls.scrollMaxIcon:DisableHitTest()
@@ -195,14 +184,14 @@ function SetLayout()
         controls.scrollMaxIcon:SetTexture(textures.maxIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.pageMin:SetNewTextures(textures.minBtn.up, textures.minBtn.down, textures.minBtn.over, textures.minBtn.dis)
     controls.pageMin:SetTexture(textures.minBtn.up)
     controls.pageMin.Right:Set(controls.scrollMin.Left)
     LayoutHelpers.AtVerticalCenterIn(controls.pageMin, controls.choices)
     LayoutHelpers.ResetLeft(controls.pageMin)
     LayoutHelpers.ResetBottom(controls.pageMin)
-    
+
     controls.pageMinIcon:SetTexture(textures.pageMinIcon.on)
     LayoutHelpers.AtCenterIn(controls.pageMinIcon, controls.pageMin)
     controls.pageMinIcon:DisableHitTest()
@@ -214,14 +203,14 @@ function SetLayout()
         controls.pageMinIcon:SetTexture(textures.pageMinIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.pageMax:SetNewTextures(textures.maxBtn.up, textures.maxBtn.down, textures.maxBtn.over, textures.maxBtn.dis)
     controls.pageMax:SetTexture(textures.maxBtn.up)
     controls.pageMax.Left:Set(controls.scrollMax.Right)
     LayoutHelpers.AtVerticalCenterIn(controls.pageMax, controls.choices)
     LayoutHelpers.ResetRight(controls.pageMax)
     LayoutHelpers.ResetBottom(controls.pageMax)
-    
+
     controls.pageMaxIcon:SetTexture(textures.pageMaxIcon.on)
     LayoutHelpers.AtCenterIn(controls.pageMaxIcon, controls.pageMax)
     controls.pageMaxIcon:DisableHitTest()
@@ -233,13 +222,13 @@ function SetLayout()
         controls.pageMaxIcon:SetTexture(textures.pageMaxIcon.on)
         Button.OnEnable(self)
     end
-    
+
     LayoutHelpers.AnchorToBottom(controls.secondaryChoices, controls.choices, 1)
     LayoutHelpers.AnchorToTop(controls.secondaryChoices, controls.secondaryChoices, -50)
     controls.secondaryChoices.Left:Set(controls.choices.Left)
     controls.secondaryChoices.Right:Set(controls.choices.Right)
     controls.secondaryChoices:SetToVertical(false)
-    
+
     controls.secondaryChoicesBGMin:SetTexture(UIUtil.UIFile('/game/construct-panel/que-panel_bmp_l.dds'))
     LayoutHelpers.AtLeftTopIn(controls.secondaryChoicesBGMin, controls.secondaryChoices, -46)
     controls.secondaryChoicesBGMax:SetTexture(UIUtil.UIFile('/game/construct-panel/que-panel_bmp_r.dds'))
@@ -251,23 +240,23 @@ function SetLayout()
     controls.secondaryChoicesBGMid.Left:Set(controls.secondaryChoicesBGMin.Right)
     controls.secondaryChoicesBGMid.Right:Set(controls.secondaryChoicesBGMax.Left)
     LayoutHelpers.ResetBottom(controls.secondaryChoicesBGMid)
-    
+
     controls.secondaryChoicesBGMin.Depth:Set(function() return controls.secondaryChoices.Depth() - 1 end)
     controls.secondaryChoicesBGMax.Depth:Set(function() return controls.secondaryChoices.Depth() - 1 end)
     controls.secondaryChoicesBGMid.Depth:Set(function() return controls.secondaryChoices.Depth() - 1 end)
-    
+
     LayoutHelpers.AtLeftIn(controls.secondaryProgress, controls.secondaryChoices, 5)
     LayoutHelpers.AtTopIn(controls.secondaryProgress, controls.secondaryChoices, 42)
     controls.secondaryProgress.Depth:Set(function() return controls.secondaryChoices.Depth() + 5 end)
     LayoutHelpers.SetDimensions(controls.secondaryProgress, 40, 4)
-    
+
     controls.secondaryScrollMin:SetNewTextures(textures.midBtn.up, textures.midBtn.down, textures.midBtn.over, textures.midBtn.dis)
     controls.secondaryScrollMin:SetTexture(textures.midBtn.up)
     LayoutHelpers.AnchorToLeft(controls.secondaryScrollMin, controls.secondaryChoices, 4)
     LayoutHelpers.AtVerticalCenterIn(controls.secondaryScrollMin, controls.secondaryChoices)
     LayoutHelpers.ResetLeft(controls.secondaryScrollMin)
     LayoutHelpers.ResetBottom(controls.secondaryScrollMin)
-    
+
     controls.secondaryScrollMinIcon:SetTexture(textures.minIcon.on)
     LayoutHelpers.AtCenterIn(controls.secondaryScrollMinIcon, controls.secondaryScrollMin)
     controls.secondaryScrollMinIcon:DisableHitTest()
@@ -279,14 +268,14 @@ function SetLayout()
         controls.secondaryScrollMinIcon:SetTexture(textures.minIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.secondaryScrollMax:SetNewTextures(textures.midBtn.up, textures.midBtn.down, textures.midBtn.over, textures.midBtn.dis)
     controls.secondaryScrollMax:SetTexture(textures.midBtn.up)
     controls.secondaryScrollMax.Left:Set(controls.secondaryChoices.Right)
     LayoutHelpers.AtVerticalCenterIn(controls.secondaryScrollMax, controls.secondaryChoices)
     LayoutHelpers.ResetRight(controls.secondaryScrollMax)
     LayoutHelpers.ResetBottom(controls.secondaryScrollMax)
-    
+
     controls.secondaryScrollMaxIcon:SetTexture(textures.maxIcon.on)
     LayoutHelpers.AtCenterIn(controls.secondaryScrollMaxIcon, controls.secondaryScrollMax)
     controls.secondaryScrollMaxIcon:DisableHitTest()
@@ -298,14 +287,14 @@ function SetLayout()
         controls.secondaryScrollMaxIcon:SetTexture(textures.maxIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.secondaryPageMin:SetNewTextures(textures.minBtn.up, textures.minBtn.down, textures.minBtn.over, textures.minBtn.dis)
     controls.secondaryPageMin:SetTexture(textures.minBtn.up)
     controls.secondaryPageMin.Right:Set(controls.secondaryScrollMin.Left)
     LayoutHelpers.AtVerticalCenterIn(controls.secondaryPageMin, controls.secondaryChoices)
     LayoutHelpers.ResetBottom(controls.secondaryPageMin)
     LayoutHelpers.ResetLeft(controls.secondaryPageMin)
-    
+
     controls.secondaryPageMinIcon:SetTexture(textures.pageMinIcon.on)
     LayoutHelpers.AtCenterIn(controls.secondaryPageMinIcon, controls.secondaryPageMin)
     controls.secondaryPageMinIcon:DisableHitTest()
@@ -317,13 +306,13 @@ function SetLayout()
         controls.secondaryPageMinIcon:SetTexture(textures.pageMinIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.secondaryPageMax:SetNewTextures(textures.maxBtn.up, textures.maxBtn.down, textures.maxBtn.over, textures.maxBtn.dis)
     controls.secondaryPageMax:SetTexture(textures.maxBtn.up)
     controls.secondaryPageMax.Left:Set(controls.scrollMax.Right)
     LayoutHelpers.AtVerticalCenterIn(controls.secondaryPageMax, controls.secondaryChoices)
     LayoutHelpers.ResetBottom(controls.secondaryPageMax)
-    
+
     controls.secondaryPageMaxIcon:SetTexture(textures.pageMaxIcon.on)
     LayoutHelpers.AtCenterIn(controls.secondaryPageMaxIcon, controls.secondaryPageMax)
     controls.secondaryPageMaxIcon:DisableHitTest()
@@ -335,14 +324,14 @@ function SetLayout()
         controls.secondaryPageMaxIcon:SetTexture(textures.pageMaxIcon.on)
         Button.OnEnable(self)
     end
-    
-    controls.extraBtn1:SetNewTextures(textures.midBtn.up, textures.midBtn.selected, textures.midBtn.over, 
+
+    controls.extraBtn1:SetNewTextures(textures.midBtn.up, textures.midBtn.selected, textures.midBtn.over,
         textures.midBtn.over, textures.midBtn.dis, textures.midBtn.dis)
-    controls.extraBtn2:SetNewTextures(textures.midBtn.up, textures.midBtn.selected, textures.midBtn.over, 
+    controls.extraBtn2:SetNewTextures(textures.midBtn.up, textures.midBtn.selected, textures.midBtn.over,
         textures.midBtn.over, textures.midBtn.dis, textures.midBtn.dis)
     LayoutHelpers.AtLeftTopIn(controls.extraBtn1, controls.minBG, 10, 31)
     LayoutHelpers.Below(controls.extraBtn2, controls.extraBtn1, 1)
-    
+
     controls.constructionGroup:DisableHitTest()
     LayoutTabs(import('/lua/ui/game/construction.lua').controls)
     controls.constructionGroup:Hide()
@@ -350,7 +339,7 @@ end
 
 function LayoutTabs(controls)
     local prevControl = false
-    
+
     local tabFiles = {
         construction = '/game/construct-tab_btn/top_tab_btn_',
         selection = '/game/construct-tab_btn/mid_tab_btn_',
@@ -365,52 +354,52 @@ function LayoutTabs(controls)
         LCH = '/game/construct-tech_btn/left_upgrade_btn_',
         RCH = '/game/construct-tech_btn/r_upgrade_btn_',
         Back = '/game/construct-tech_btn/m_upgrade_btn_',
-		Command = '/game/construct-tech_btn/left_upgrade_btn_',
+        Command = '/game/construct-tech_btn/left_upgrade_btn_',
     }
-    
+
     local function GetTabTextures(id)
         if tabFiles[id] then
             local pre = tabFiles[id]
             return UIUtil.UIFile(pre..'up_bmp.dds'), UIUtil.UIFile(pre..'sel_bmp.dds'),
-                UIUtil.UIFile(pre..'over_bmp.dds'), UIUtil.UIFile(pre..'down_bmp.dds'), 
+                UIUtil.UIFile(pre..'over_bmp.dds'), UIUtil.UIFile(pre..'down_bmp.dds'),
                 UIUtil.UIFile(pre..'dis_bmp.dds'), UIUtil.UIFile(pre..'dis_bmp.dds')
         elseif techFiles[id] then
             local pre = techFiles[id]
             return UIUtil.UIFile(pre..'up.dds'), UIUtil.UIFile(pre..'selected.dds'),
-                UIUtil.UIFile(pre..'over.dds'), UIUtil.UIFile(pre..'down.dds'), 
+                UIUtil.UIFile(pre..'over.dds'), UIUtil.UIFile(pre..'down.dds'),
                 UIUtil.UIFile(pre..'dis.dds'), UIUtil.UIFile(pre..'dis.dds')
         end
     end
-    
+
     local function SetupTab(control)
         control:SetNewTextures(GetTabTextures(control.ID))
         control:UseAlphaHitTest(false)
-               
+
         control.OnDisable = function(self)
             self.disabledGroup:Enable()
             Checkbox.OnDisable(self)
         end
-        
+
         LayoutHelpers.SetDimensions(control.disabledGroup, 40, 25)
         LayoutHelpers.AtCenterIn(control.disabledGroup, control)
-        
+
         control.OnEnable = function(self)
             self.disabledGroup:Disable()
             Checkbox.OnEnable(self)
         end
     end
-    
+
     if table.getsize(controls.tabs) > 0 then
         for id, control in controls.tabs do
             SetupTab(control)
-             
+
             if not prevControl then
                 LayoutHelpers.AtLeftTopIn(control, controls.minBG, 82, 0)
             else
                 local offset = 0
                 LayoutHelpers.RightOf(control, prevControl, offset)
             end
-            
+
             prevControl = control
         end
         controls.midBG1:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_m1.dds'))
@@ -418,10 +407,10 @@ function LayoutTabs(controls)
         controls.midBG2:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_m2.dds'))
         controls.midBG3:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_m3.dds'))
         controls.minBG:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_l.dds'))
-        LayoutHelpers.SetDimensions(controls.minBG, controls.minBG.BitmapWidth(), controls.minBG.BitmapHeight()) -- TODO: This is an ugly hack for the problem described above
-        LayoutHelpers.SetDimensions(controls.midBG1, controls.midBG1.BitmapWidth(), controls.midBG1.BitmapHeight()) -- TODO
-        LayoutHelpers.SetDimensions(controls.midBG2, controls.midBG2.BitmapWidth(), controls.midBG2.BitmapHeight()) -- TODO
-        LayoutHelpers.SetDimensions(controls.midBG3, controls.midBG3.BitmapWidth(), controls.midBG3.BitmapHeight()) -- TODO
+        LayoutHelpers.SetDimensions(controls.minBG, controls.minBG.BitmapWidth, controls.minBG.BitmapHeight)
+        LayoutHelpers.SetDimensions(controls.midBG1, controls.midBG1.BitmapWidth, controls.midBG1.BitmapHeight)
+        LayoutHelpers.SetDimensions(controls.midBG2, controls.midBG2.BitmapWidth, controls.midBG2.BitmapHeight)
+        LayoutHelpers.SetDimensions(controls.midBG3, controls.midBG3.BitmapWidth, controls.midBG3.BitmapHeight)
         LayoutHelpers.AtLeftIn(controls.minBG, controls.constructionGroup, 67)
         LayoutHelpers.AtBottomIn(controls.maxBG, controls.minBG, 1)
         LayoutHelpers.AtBottomIn(controls.minBG, controls.constructionGroup, 4)
@@ -430,31 +419,32 @@ function LayoutTabs(controls)
         controls.midBG2:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_s_bmp_m.dds'))
         controls.midBG3:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_s_bmp_m.dds'))
         controls.minBG:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_s_bmp_l.dds'))
-        LayoutHelpers.SetDimensions(controls.minBG, controls.minBG.BitmapWidth(), controls.minBG.BitmapHeight()) -- TODO
-        LayoutHelpers.SetDimensions(controls.midBG1, controls.midBG1.BitmapWidth(), controls.midBG1.BitmapHeight()) -- TODO
-        LayoutHelpers.SetDimensions(controls.midBG2, controls.midBG2.BitmapWidth(), controls.midBG2.BitmapHeight()) -- TODO
-        LayoutHelpers.SetDimensions(controls.midBG3, controls.midBG3.BitmapWidth(), controls.midBG3.BitmapHeight()) -- TODO
+        LayoutHelpers.SetDimensions(controls.minBG, controls.minBG.BitmapWidth, controls.minBG.BitmapHeight)
+        LayoutHelpers.SetDimensions(controls.midBG1, controls.midBG1.BitmapWidth, controls.midBG1.BitmapHeight)
+        LayoutHelpers.SetDimensions(controls.midBG2, controls.midBG2.BitmapWidth, controls.midBG2.BitmapHeight)
+        LayoutHelpers.SetDimensions(controls.midBG3, controls.midBG3.BitmapWidth, controls.midBG3.BitmapHeight)
         LayoutHelpers.AtLeftIn(controls.minBG, controls.constructionGroup, 69)
         LayoutHelpers.AtBottomIn(controls.maxBG, controls.minBG, 0)
         LayoutHelpers.AtBottomIn(controls.minBG, controls.constructionGroup, 5)
     end
-    
+
     SetupTab(controls.constructionTab)
     LayoutHelpers.AtLeftTopIn(controls.constructionTab, controls.constructionGroup, 0, 14)
     SetupTab(controls.selectionTab)
     LayoutHelpers.Below(controls.selectionTab, controls.constructionTab, -16)
     SetupTab(controls.enhancementTab)
     LayoutHelpers.Below(controls.enhancementTab, controls.selectionTab, -16)
-    
+
 end
 
 function OnTabChangeLayout(type)
     local controls = import('/lua/ui/game/construction.lua').controls
     if type != 'selection' then
-		LayoutHelpers.AtLeftIn(controls.choices, controls.minBG, 85)
-		LayoutHelpers.AtRightIn(controls.choices, controls.maxBG, 49)
+        LayoutHelpers.AtLeftIn(controls.choices, controls.minBG, 85)
+        LayoutHelpers.AtRightIn(controls.choices, controls.maxBG, 49)
     end
     if type == 'construction' or type == 'templates' then
+        controls.extraBtn1.icon:Show()
         controls.extraBtn1.icon.OnTexture = UIUtil.UIFile('/game/construct-sm_btn/infinite_on.dds')
         controls.extraBtn1.icon.OffTexture = UIUtil.UIFile('/game/construct-sm_btn/infinite_off.dds')
         if controls.extraBtn1:IsDisabled() then
@@ -470,11 +460,12 @@ function OnTabChangeLayout(type)
         else
             controls.extraBtn2.icon:SetTexture(controls.extraBtn2.icon.OnTexture)
         end
-        
+
         LayoutHelpers.AtTopIn(controls.choices, controls.minBG, 31)
         LayoutHelpers.AtLeftTopIn(controls.extraBtn1, controls.minBG, 10, 31)
         LayoutHelpers.Below(controls.extraBtn2, controls.extraBtn1, 1)
     elseif type == 'selection' then
+        controls.extraBtn1.icon:Show()
         controls.extraBtn1.icon.OnTexture = UIUtil.UIFile('/game/construct-sm_btn/template_on.dds')
         controls.extraBtn1.icon.OffTexture = UIUtil.UIFile('/game/construct-sm_btn/template_off.dds')
         if controls.extraBtn1:IsDisabled() then
@@ -493,8 +484,8 @@ function OnTabChangeLayout(type)
         LayoutHelpers.AtTopIn(controls.choices, controls.minBG, 4)
         LayoutHelpers.AtLeftTopIn(controls.extraBtn1, controls.minBG, 8, 4)
         LayoutHelpers.Below(controls.extraBtn2, controls.extraBtn1, 1)
-		LayoutHelpers.AtLeftIn(controls.choices, controls.minBG, 83)
-		LayoutHelpers.AtRightIn(controls.choices, controls.maxBG, 49)
+        LayoutHelpers.AtLeftIn(controls.choices, controls.minBG, 83)
+        LayoutHelpers.AtRightIn(controls.choices, controls.maxBG, 49)
     else
         LayoutHelpers.AtTopIn(controls.choices, controls.minBG, 31)
         LayoutHelpers.AtLeftTopIn(controls.extraBtn1, controls.minBG, 10, 31)

--- a/gamedata/lua/lua/ui/game/layouts/construction_right.lua
+++ b/gamedata/lua/lua/ui/game/layouts/construction_right.lua
@@ -47,50 +47,48 @@ function SetLayout()
     local controls = import('/lua/ui/game/construction.lua').controls
     local ordersControl = import('/lua/ui/game/construction.lua').ordersControl
     local controlClusterGroup = import('/lua/ui/game/construction.lua').controlClusterGroup
-    controls.constructionGroup.Top:Set(function() return controlClusterGroup.Top() + 12 end)
+    LayoutHelpers.AtTopIn(controls.constructionGroup, controlClusterGroup, 12)
     controls.constructionGroup.Bottom:Set(controlClusterGroup.Bottom)
     if ordersControl then
-        controls.constructionGroup.Right:Set(function() return ordersControl.Left() - 14 end)
+        LayoutHelpers.AnchorToLeft(controls.constructionGroup, ordersControl, 14)
     else
         controls.constructionGroup.Right:Set(controlClusterGroup.Right)
     end
-    controls.constructionGroup.Left:Set(function() return controlClusterGroup.Left() + 8 end)
-    
+    LayoutHelpers.AtLeftIn(controls.constructionGroup, controlClusterGroup, 8)
+
     controls.minBG:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_l.dds'))
     LayoutHelpers.AtBottomIn(controls.minBG, controls.constructionGroup, 4)
     LayoutHelpers.AtLeftIn(controls.minBG, controls.constructionGroup, 67)
     LayoutHelpers.ResetRight(controls.minBG)
     LayoutHelpers.ResetTop(controls.minBG)
-    controls.minBG.Width:Set(controls.minBG.BitmapWidth)
-    controls.minBG.Height:Set(controls.minBG.BitmapHeight)
-    
+    LayoutHelpers.SetDimensions(controls.minBG, controls.minBG.BitmapWidth, controls.minBG.BitmapHeight)
+
     controls.leftBracketMin:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_t.dds'))
-    controls.leftBracketMin.Left:Set(function() return controls.constructionGroup.Left() - 8 end)
-    controls.leftBracketMin.Top:Set(function() return controls.constructionGroup.Top() + 17 end)
-    
+    LayoutHelpers.AtLeftIn(controls.leftBracketMin, controls.constructionGroup, -8)
+    LayoutHelpers.AtTopIn(controls.leftBracketMin, controls.constructionGroup, 17)
+
     controls.leftBracketMax:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_b.dds'))
     controls.leftBracketMax.Left:Set(controls.leftBracketMin.Left)
-    controls.leftBracketMax.Bottom:Set(function() return controls.constructionGroup.Bottom() + 0 end)
-    
+    controls.leftBracketMax.Bottom:Set(controls.constructionGroup.Bottom)
+
     controls.leftBracketMid:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_m.dds'))
-    controls.leftBracketMid.Left:Set(function() return controls.leftBracketMin.Left() + 7 end)
+    LayoutHelpers.AtLeftIn(controls.leftBracketMid, controls.leftBracketMin, 7)
     controls.leftBracketMid.Bottom:Set(controls.leftBracketMax.Top)
     controls.leftBracketMid.Top:Set(controls.leftBracketMin.Bottom)
-    
+
     controls.rightBracketMin:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_t.dds'))
-    controls.rightBracketMin.Right:Set(function() return controls.maxBG.Right() + 10 end)
-    controls.rightBracketMin.Top:Set(function() return controls.maxBG.Top() - 1 end)
-    
+    LayoutHelpers.AtRightIn(controls.rightBracketMin, controls.maxBG, -10)
+    LayoutHelpers.AtTopIn(controls.rightBracketMin, controls.maxBG, -1)
+
     controls.rightBracketMax:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_b.dds'))
-    controls.rightBracketMax.Right:Set(function() return controls.maxBG.Right() + 10 end)
-    controls.rightBracketMax.Bottom:Set(function() return controls.maxBG.Bottom() + 2 end)
-    
+    LayoutHelpers.AtRightIn(controls.rightBracketMax, controls.maxBG, -10)
+    LayoutHelpers.AtBottomIn(controls.rightBracketMax, controls.maxBG, -2)
+
     controls.rightBracketMid:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_m.dds'))
-    controls.rightBracketMid.Right:Set(function() return controls.maxBG.Right() + 10 end)
+    LayoutHelpers.AtRightIn(controls.rightBracketMid, controls.maxBG, -10)
     controls.rightBracketMid.Bottom:Set(controls.rightBracketMax.Top)
     controls.rightBracketMid.Top:Set(controls.rightBracketMin.Bottom)
 
-    
     controls.maxBG:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_r.dds'))
     LayoutHelpers.AtBottomIn(controls.maxBG, controls.minBG, 1)
     LayoutHelpers.AtRightIn(controls.maxBG, controls.constructionGroup, 2)
@@ -103,38 +101,35 @@ function SetLayout()
     controls.midBG1:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_m1.dds'))
     controls.midBG1.Left:Set(controls.minBG.Right)
     controls.midBG1.Bottom:Set(controls.minBG.Bottom)
-    controls.midBG1.Height:Set(controls.midBG1.BitmapHeight)
-    controls.midBG1.Width:Set(controls.midBG1.BitmapWidth)
+    LayoutHelpers.SetDimensions(controls.midBG1, controls.midBG1.BitmapWidth, controls.midBG1.BitmapHeight)
     LayoutHelpers.ResetTop(controls.midBG1)
-    
+
     if not controls.midBG2 then
         controls.midBG2 = Bitmap(controls.constructionGroup)
     end
     controls.midBG2:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_m2.dds'))
     controls.midBG2.Left:Set(controls.midBG1.Right)
     controls.midBG2.Bottom:Set(controls.minBG.Bottom)
-    controls.midBG2.Height:Set(controls.midBG2.BitmapHeight)
-    controls.midBG2.Width:Set(controls.midBG2.BitmapWidth)
+    LayoutHelpers.SetDimensions(controls.midBG2, controls.midBG2.BitmapWidth, controls.midBG2.BitmapHeight)
     LayoutHelpers.ResetTop(controls.midBG2)
-    
+
     controls.midBG3:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_m3.dds'))
     controls.midBG3.Left:Set(controls.midBG2.Right)
     controls.midBG3.Right:Set(controls.maxBG.Left)
     controls.midBG3.Bottom:Set(controls.maxBG.Bottom)
-    controls.midBG3:SetTiled(true)
-    controls.midBG3.Height:Set(controls.midBG3.BitmapHeight)
+    LayoutHelpers.SetHeight(controls.midBG3, controls.midBG3.BitmapHeight)
     LayoutHelpers.ResetWidth(controls.midBG3)
     LayoutHelpers.ResetTop(controls.midBG3)
-    controls.midBG3.Height:Set(controls.midBG3.BitmapHeight)
-    
-    controls.choices.Top:Set(function() return controls.minBG.Top() + 5 end)
-    controls.choices.Height:Set(50)
+    LayoutHelpers.SetHeight(controls.midBG3, controls.midBG3.BitmapHeight)
+
+    LayoutHelpers.AtTopIn(controls.choices, controls.minBG, 5)
+    LayoutHelpers.SetHeight(controls.choices, 50)
     controls.choices:SetToVertical(false)
-    controls.choices.Left:Set(function() return controls.minBG.Left() + 26 end)
-    controls.choices.Right:Set(function() return controls.maxBG.Right() - 25 end)
+    LayoutHelpers.AtLeftIn(controls.choices, controls.minBG, 26)
+    LayoutHelpers.AtRightIn(controls.choices, controls.maxBG, 25)
     LayoutHelpers.ResetWidth(controls.choices)
     LayoutHelpers.ResetBottom(controls.choices)
-    
+
     controls.choicesBGMin:SetTexture(UIUtil.UIFile('/game/construct-panel/que-panel_bmp_l.dds'))
     LayoutHelpers.AtLeftTopIn(controls.choicesBGMin, controls.choices, -46)
     controls.choicesBGMax:SetTexture(UIUtil.UIFile('/game/construct-panel/que-panel_bmp_r.dds'))
@@ -146,20 +141,19 @@ function SetLayout()
     LayoutHelpers.ResetBottom(controls.choicesBGMid)
     controls.choicesBGMid.Left:Set(controls.choicesBGMin.Right)
     controls.choicesBGMid.Right:Set(controls.choicesBGMax.Left)
-    
+
     controls.choicesBGMax.Depth:Set(function() return controls.choices.Depth() - 1 end)
     controls.choicesBGMid.Depth:Set(function() return controls.choices.Depth() - 1 end)
     controls.choicesBGMin.Depth:Set(function() return controls.choices.Depth() - 1 end)
-    
+
     controls.scrollMin:SetNewTextures(textures.midBtn.up, textures.midBtn.down, textures.midBtn.over, textures.midBtn.dis)
     controls.scrollMin:SetTexture(textures.midBtn.up)
-    controls.scrollMin.Right:Set(function() return controls.choices.Left() - 4 end)
+    LayoutHelpers.AnchorToLeft(controls.scrollMin, controls.choices, 4)
     LayoutHelpers.AtVerticalCenterIn(controls.scrollMin, controls.choices)
     LayoutHelpers.ResetLeft(controls.scrollMin)
     LayoutHelpers.ResetBottom(controls.scrollMin)
-    controls.scrollMin.Height:Set(controls.scrollMin.BitmapHeight)
-    controls.scrollMin.Width:Set(controls.scrollMin.BitmapWidth)
-    
+    LayoutHelpers.SetDimensions(controls.scrollMin, controls.scrollMin.BitmapWidth, controls.scrollMin.BitmapHeight)
+
     controls.scrollMinIcon:SetTexture(textures.minIcon.on)
     LayoutHelpers.AtCenterIn(controls.scrollMinIcon, controls.scrollMin)
     controls.scrollMinIcon:DisableHitTest()
@@ -171,14 +165,14 @@ function SetLayout()
         controls.scrollMinIcon:SetTexture(textures.minIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.scrollMax:SetNewTextures(textures.midBtn.up, textures.midBtn.down, textures.midBtn.over, textures.midBtn.dis)
     controls.scrollMax:SetTexture(textures.midBtn.up)
     controls.scrollMax.Left:Set(controls.choices.Right)
     LayoutHelpers.AtVerticalCenterIn(controls.scrollMax, controls.choices)
     LayoutHelpers.ResetRight(controls.scrollMax)
     LayoutHelpers.ResetBottom(controls.scrollMax)
-    
+
     controls.scrollMaxIcon:SetTexture(textures.maxIcon.on)
     LayoutHelpers.AtCenterIn(controls.scrollMaxIcon, controls.scrollMax)
     controls.scrollMaxIcon:DisableHitTest()
@@ -190,14 +184,14 @@ function SetLayout()
         controls.scrollMaxIcon:SetTexture(textures.maxIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.pageMin:SetNewTextures(textures.minBtn.up, textures.minBtn.down, textures.minBtn.over, textures.minBtn.dis)
     controls.pageMin:SetTexture(textures.minBtn.up)
     controls.pageMin.Right:Set(controls.scrollMin.Left)
     LayoutHelpers.AtVerticalCenterIn(controls.pageMin, controls.choices)
     LayoutHelpers.ResetLeft(controls.pageMin)
     LayoutHelpers.ResetBottom(controls.pageMin)
-    
+
     controls.pageMinIcon:SetTexture(textures.pageMinIcon.on)
     LayoutHelpers.AtCenterIn(controls.pageMinIcon, controls.pageMin)
     controls.pageMinIcon:DisableHitTest()
@@ -209,14 +203,14 @@ function SetLayout()
         controls.pageMinIcon:SetTexture(textures.pageMinIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.pageMax:SetNewTextures(textures.maxBtn.up, textures.maxBtn.down, textures.maxBtn.over, textures.maxBtn.dis)
     controls.pageMax:SetTexture(textures.maxBtn.up)
     controls.pageMax.Left:Set(controls.scrollMax.Right)
     LayoutHelpers.AtVerticalCenterIn(controls.pageMax, controls.choices)
     LayoutHelpers.ResetRight(controls.pageMax)
     LayoutHelpers.ResetBottom(controls.pageMax)
-    
+
     controls.pageMaxIcon:SetTexture(textures.pageMaxIcon.on)
     LayoutHelpers.AtCenterIn(controls.pageMaxIcon, controls.pageMax)
     controls.pageMaxIcon:DisableHitTest()
@@ -228,13 +222,13 @@ function SetLayout()
         controls.pageMaxIcon:SetTexture(textures.pageMaxIcon.on)
         Button.OnEnable(self)
     end
-    
-    controls.secondaryChoices.Top:Set(function() return controls.choices.Bottom() + 1 end)
-    controls.secondaryChoices.Bottom:Set(function() return controls.secondaryChoices.Top() + 50 end)
+
+    LayoutHelpers.AnchorToBottom(controls.secondaryChoices, controls.choices, 1)
+    LayoutHelpers.AnchorToTop(controls.secondaryChoices, controls.secondaryChoices, -50)
     controls.secondaryChoices.Left:Set(controls.choices.Left)
     controls.secondaryChoices.Right:Set(controls.choices.Right)
     controls.secondaryChoices:SetToVertical(false)
-    
+
     controls.secondaryChoicesBGMin:SetTexture(UIUtil.UIFile('/game/construct-panel/que-panel_bmp_l.dds'))
     LayoutHelpers.AtLeftTopIn(controls.secondaryChoicesBGMin, controls.secondaryChoices, -46)
     controls.secondaryChoicesBGMax:SetTexture(UIUtil.UIFile('/game/construct-panel/que-panel_bmp_r.dds'))
@@ -246,24 +240,23 @@ function SetLayout()
     controls.secondaryChoicesBGMid.Left:Set(controls.secondaryChoicesBGMin.Right)
     controls.secondaryChoicesBGMid.Right:Set(controls.secondaryChoicesBGMax.Left)
     LayoutHelpers.ResetBottom(controls.secondaryChoicesBGMid)
-    
+
     controls.secondaryChoicesBGMin.Depth:Set(function() return controls.secondaryChoices.Depth() - 1 end)
     controls.secondaryChoicesBGMax.Depth:Set(function() return controls.secondaryChoices.Depth() - 1 end)
     controls.secondaryChoicesBGMid.Depth:Set(function() return controls.secondaryChoices.Depth() - 1 end)
-    
+
     LayoutHelpers.AtLeftIn(controls.secondaryProgress, controls.secondaryChoices, 5)
-    LayoutHelpers.AtTopIn(controls.secondaryProgress, controls.secondaryChoices, 43)
+    LayoutHelpers.AtTopIn(controls.secondaryProgress, controls.secondaryChoices, 42)
     controls.secondaryProgress.Depth:Set(function() return controls.secondaryChoices.Depth() + 5 end)
-    controls.secondaryProgress.Width:Set(40)
-    controls.secondaryProgress.Height:Set(4)
-    
+    LayoutHelpers.SetDimensions(controls.secondaryProgress, 40, 4)
+
     controls.secondaryScrollMin:SetNewTextures(textures.midBtn.up, textures.midBtn.down, textures.midBtn.over, textures.midBtn.dis)
     controls.secondaryScrollMin:SetTexture(textures.midBtn.up)
-    controls.secondaryScrollMin.Right:Set(function() return controls.secondaryChoices.Left() - 4 end)
+    LayoutHelpers.AnchorToLeft(controls.secondaryScrollMin, controls.secondaryChoices, 4)
     LayoutHelpers.AtVerticalCenterIn(controls.secondaryScrollMin, controls.secondaryChoices)
     LayoutHelpers.ResetLeft(controls.secondaryScrollMin)
     LayoutHelpers.ResetBottom(controls.secondaryScrollMin)
-    
+
     controls.secondaryScrollMinIcon:SetTexture(textures.minIcon.on)
     LayoutHelpers.AtCenterIn(controls.secondaryScrollMinIcon, controls.secondaryScrollMin)
     controls.secondaryScrollMinIcon:DisableHitTest()
@@ -275,14 +268,14 @@ function SetLayout()
         controls.secondaryScrollMinIcon:SetTexture(textures.minIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.secondaryScrollMax:SetNewTextures(textures.midBtn.up, textures.midBtn.down, textures.midBtn.over, textures.midBtn.dis)
     controls.secondaryScrollMax:SetTexture(textures.midBtn.up)
     controls.secondaryScrollMax.Left:Set(controls.secondaryChoices.Right)
     LayoutHelpers.AtVerticalCenterIn(controls.secondaryScrollMax, controls.secondaryChoices)
     LayoutHelpers.ResetRight(controls.secondaryScrollMax)
     LayoutHelpers.ResetBottom(controls.secondaryScrollMax)
-    
+
     controls.secondaryScrollMaxIcon:SetTexture(textures.maxIcon.on)
     LayoutHelpers.AtCenterIn(controls.secondaryScrollMaxIcon, controls.secondaryScrollMax)
     controls.secondaryScrollMaxIcon:DisableHitTest()
@@ -294,14 +287,14 @@ function SetLayout()
         controls.secondaryScrollMaxIcon:SetTexture(textures.maxIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.secondaryPageMin:SetNewTextures(textures.minBtn.up, textures.minBtn.down, textures.minBtn.over, textures.minBtn.dis)
     controls.secondaryPageMin:SetTexture(textures.minBtn.up)
     controls.secondaryPageMin.Right:Set(controls.secondaryScrollMin.Left)
     LayoutHelpers.AtVerticalCenterIn(controls.secondaryPageMin, controls.secondaryChoices)
     LayoutHelpers.ResetBottom(controls.secondaryPageMin)
     LayoutHelpers.ResetLeft(controls.secondaryPageMin)
-    
+
     controls.secondaryPageMinIcon:SetTexture(textures.pageMinIcon.on)
     LayoutHelpers.AtCenterIn(controls.secondaryPageMinIcon, controls.secondaryPageMin)
     controls.secondaryPageMinIcon:DisableHitTest()
@@ -313,13 +306,13 @@ function SetLayout()
         controls.secondaryPageMinIcon:SetTexture(textures.pageMinIcon.on)
         Button.OnEnable(self)
     end
-    
+
     controls.secondaryPageMax:SetNewTextures(textures.maxBtn.up, textures.maxBtn.down, textures.maxBtn.over, textures.maxBtn.dis)
     controls.secondaryPageMax:SetTexture(textures.maxBtn.up)
     controls.secondaryPageMax.Left:Set(controls.scrollMax.Right)
     LayoutHelpers.AtVerticalCenterIn(controls.secondaryPageMax, controls.secondaryChoices)
     LayoutHelpers.ResetBottom(controls.secondaryPageMax)
-    
+
     controls.secondaryPageMaxIcon:SetTexture(textures.pageMaxIcon.on)
     LayoutHelpers.AtCenterIn(controls.secondaryPageMaxIcon, controls.secondaryPageMax)
     controls.secondaryPageMaxIcon:DisableHitTest()
@@ -331,14 +324,14 @@ function SetLayout()
         controls.secondaryPageMaxIcon:SetTexture(textures.pageMaxIcon.on)
         Button.OnEnable(self)
     end
-    
-    controls.extraBtn1:SetNewTextures(textures.midBtn.up, textures.midBtn.selected, textures.midBtn.over, 
+
+    controls.extraBtn1:SetNewTextures(textures.midBtn.up, textures.midBtn.selected, textures.midBtn.over,
         textures.midBtn.over, textures.midBtn.dis, textures.midBtn.dis)
-    controls.extraBtn2:SetNewTextures(textures.midBtn.up, textures.midBtn.selected, textures.midBtn.over, 
+    controls.extraBtn2:SetNewTextures(textures.midBtn.up, textures.midBtn.selected, textures.midBtn.over,
         textures.midBtn.over, textures.midBtn.dis, textures.midBtn.dis)
     LayoutHelpers.AtLeftTopIn(controls.extraBtn1, controls.minBG, 10, 31)
     LayoutHelpers.Below(controls.extraBtn2, controls.extraBtn1, 1)
-    
+
     controls.constructionGroup:DisableHitTest()
     LayoutTabs(import('/lua/ui/game/construction.lua').controls)
     controls.constructionGroup:Hide()
@@ -346,7 +339,7 @@ end
 
 function LayoutTabs(controls)
     local prevControl = false
-    
+
     local tabFiles = {
         construction = '/game/construct-tab_btn/top_tab_btn_',
         selection = '/game/construct-tab_btn/mid_tab_btn_',
@@ -361,52 +354,52 @@ function LayoutTabs(controls)
         LCH = '/game/construct-tech_btn/left_upgrade_btn_',
         RCH = '/game/construct-tech_btn/r_upgrade_btn_',
         Back = '/game/construct-tech_btn/m_upgrade_btn_',
+        Command = '/game/construct-tech_btn/left_upgrade_btn_',
     }
-    
+
     local function GetTabTextures(id)
         if tabFiles[id] then
             local pre = tabFiles[id]
             return UIUtil.UIFile(pre..'up_bmp.dds'), UIUtil.UIFile(pre..'sel_bmp.dds'),
-                UIUtil.UIFile(pre..'over_bmp.dds'), UIUtil.UIFile(pre..'down_bmp.dds'), 
+                UIUtil.UIFile(pre..'over_bmp.dds'), UIUtil.UIFile(pre..'down_bmp.dds'),
                 UIUtil.UIFile(pre..'dis_bmp.dds'), UIUtil.UIFile(pre..'dis_bmp.dds')
         elseif techFiles[id] then
             local pre = techFiles[id]
             return UIUtil.UIFile(pre..'up.dds'), UIUtil.UIFile(pre..'selected.dds'),
-                UIUtil.UIFile(pre..'over.dds'), UIUtil.UIFile(pre..'down.dds'), 
+                UIUtil.UIFile(pre..'over.dds'), UIUtil.UIFile(pre..'down.dds'),
                 UIUtil.UIFile(pre..'dis.dds'), UIUtil.UIFile(pre..'dis.dds')
         end
     end
-    
+
     local function SetupTab(control)
         control:SetNewTextures(GetTabTextures(control.ID))
         control:UseAlphaHitTest(false)
-               
+
         control.OnDisable = function(self)
             self.disabledGroup:Enable()
             Checkbox.OnDisable(self)
         end
-        
-        control.disabledGroup.Height:Set(25)
-        control.disabledGroup.Width:Set(40)
+
+        LayoutHelpers.SetDimensions(control.disabledGroup, 40, 25)
         LayoutHelpers.AtCenterIn(control.disabledGroup, control)
-        
+
         control.OnEnable = function(self)
             self.disabledGroup:Disable()
             Checkbox.OnEnable(self)
         end
     end
-    
+
     if table.getsize(controls.tabs) > 0 then
         for id, control in controls.tabs do
             SetupTab(control)
-             
+
             if not prevControl then
                 LayoutHelpers.AtLeftTopIn(control, controls.minBG, 82, 0)
             else
                 local offset = 0
                 LayoutHelpers.RightOf(control, prevControl, offset)
             end
-            
+
             prevControl = control
         end
         controls.midBG1:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_m1.dds'))
@@ -414,6 +407,10 @@ function LayoutTabs(controls)
         controls.midBG2:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_m2.dds'))
         controls.midBG3:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_m3.dds'))
         controls.minBG:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_bmp_l.dds'))
+        LayoutHelpers.SetDimensions(controls.minBG, controls.minBG.BitmapWidth(), controls.minBG.BitmapHeight())
+        LayoutHelpers.SetDimensions(controls.midBG1, controls.midBG1.BitmapWidth(), controls.midBG1.BitmapHeight())
+        LayoutHelpers.SetDimensions(controls.midBG2, controls.midBG2.BitmapWidth(), controls.midBG2.BitmapHeight())
+        LayoutHelpers.SetDimensions(controls.midBG3, controls.midBG3.BitmapWidth(), controls.midBG3.BitmapHeight())
         LayoutHelpers.AtLeftIn(controls.minBG, controls.constructionGroup, 67)
         LayoutHelpers.AtBottomIn(controls.maxBG, controls.minBG, 1)
         LayoutHelpers.AtBottomIn(controls.minBG, controls.constructionGroup, 4)
@@ -422,27 +419,32 @@ function LayoutTabs(controls)
         controls.midBG2:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_s_bmp_m.dds'))
         controls.midBG3:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_s_bmp_m.dds'))
         controls.minBG:SetTexture(UIUtil.UIFile('/game/construct-panel/construct-panel_s_bmp_l.dds'))
+        LayoutHelpers.SetDimensions(controls.minBG, controls.minBG.BitmapWidth(), controls.minBG.BitmapHeight())
+        LayoutHelpers.SetDimensions(controls.midBG1, controls.midBG1.BitmapWidth(), controls.midBG1.BitmapHeight())
+        LayoutHelpers.SetDimensions(controls.midBG2, controls.midBG2.BitmapWidth(), controls.midBG2.BitmapHeight())
+        LayoutHelpers.SetDimensions(controls.midBG3, controls.midBG3.BitmapWidth(), controls.midBG3.BitmapHeight())
         LayoutHelpers.AtLeftIn(controls.minBG, controls.constructionGroup, 69)
         LayoutHelpers.AtBottomIn(controls.maxBG, controls.minBG, 0)
         LayoutHelpers.AtBottomIn(controls.minBG, controls.constructionGroup, 5)
     end
-    
+
     SetupTab(controls.constructionTab)
     LayoutHelpers.AtLeftTopIn(controls.constructionTab, controls.constructionGroup, 0, 14)
     SetupTab(controls.selectionTab)
     LayoutHelpers.Below(controls.selectionTab, controls.constructionTab, -16)
     SetupTab(controls.enhancementTab)
     LayoutHelpers.Below(controls.enhancementTab, controls.selectionTab, -16)
-    
+
 end
 
 function OnTabChangeLayout(type)
     local controls = import('/lua/ui/game/construction.lua').controls
     if type != 'selection' then
-        controls.choices.Left:Set(function() return controls.minBG.Left() + 85 end)
-        controls.choices.Right:Set(function() return controls.maxBG.Right() - 49 end)
+        LayoutHelpers.AtLeftIn(controls.choices, controls.minBG, 85)
+        LayoutHelpers.AtRightIn(controls.choices, controls.maxBG, 49)
     end
     if type == 'construction' or type == 'templates' then
+        controls.extraBtn1.icon:Show()
         controls.extraBtn1.icon.OnTexture = UIUtil.UIFile('/game/construct-sm_btn/infinite_on.dds')
         controls.extraBtn1.icon.OffTexture = UIUtil.UIFile('/game/construct-sm_btn/infinite_off.dds')
         if controls.extraBtn1:IsDisabled() then
@@ -458,11 +460,12 @@ function OnTabChangeLayout(type)
         else
             controls.extraBtn2.icon:SetTexture(controls.extraBtn2.icon.OnTexture)
         end
-        
-        controls.choices.Top:Set(function() return controls.minBG.Top() + 31 end)
+
+        LayoutHelpers.AtTopIn(controls.choices, controls.minBG, 31)
         LayoutHelpers.AtLeftTopIn(controls.extraBtn1, controls.minBG, 10, 31)
         LayoutHelpers.Below(controls.extraBtn2, controls.extraBtn1, 1)
     elseif type == 'selection' then
+        controls.extraBtn1.icon:Show()
         controls.extraBtn1.icon.OnTexture = UIUtil.UIFile('/game/construct-sm_btn/template_on.dds')
         controls.extraBtn1.icon.OffTexture = UIUtil.UIFile('/game/construct-sm_btn/template_off.dds')
         if controls.extraBtn1:IsDisabled() then
@@ -478,13 +481,13 @@ function OnTabChangeLayout(type)
         else
             controls.extraBtn2.icon:SetTexture(controls.extraBtn2.icon.OnTexture)
         end
-        controls.choices.Top:Set(function() return controls.minBG.Top() + 4 end)
+        LayoutHelpers.AtTopIn(controls.choices, controls.minBG, 4)
         LayoutHelpers.AtLeftTopIn(controls.extraBtn1, controls.minBG, 8, 4)
         LayoutHelpers.Below(controls.extraBtn2, controls.extraBtn1, 1)
-        controls.choices.Left:Set(function() return controls.minBG.Left() + 83 end)
-        controls.choices.Right:Set(function() return controls.maxBG.Right() - 49 end)
+        LayoutHelpers.AtLeftIn(controls.choices, controls.minBG, 83)
+        LayoutHelpers.AtRightIn(controls.choices, controls.maxBG, 49)
     else
-        controls.choices.Top:Set(function() return controls.minBG.Top() + 31 end)
+        LayoutHelpers.AtTopIn(controls.choices, controls.minBG, 31)
         LayoutHelpers.AtLeftTopIn(controls.extraBtn1, controls.minBG, 10, 31)
         LayoutHelpers.Below(controls.extraBtn2, controls.extraBtn1, 1)
         controls.extraBtn1.icon:Hide()

--- a/gamedata/lua/lua/ui/game/layouts/controlgroups_mini.lua
+++ b/gamedata/lua/lua/ui/game/layouts/controlgroups_mini.lua
@@ -4,28 +4,28 @@ local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 
 function SetLayout()
     local controls = import('/lua/ui/game/controlgroups.lua').controls
-    
+
     controls.bgTop:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_t.dds'))
     controls.bgStretch:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_m.dds'))
     controls.bgBottom:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_b.dds'))
-    
+
     LayoutHelpers.AtRightIn(controls.bgTop, controls.container)
     LayoutHelpers.AtRightIn(controls.bgBottom, controls.container)
-    
+
     LayoutHelpers.AnchorToTop(controls.bgTop, controls.container, -70)
     controls.bgBottom.Top:Set(function() return math.max(controls.bgTop.Bottom(), controls.container.Bottom() - LayoutHelpers.ScaleNumber(20)) end)
     LayoutHelpers.AnchorToBottom(controls.bgStretch, controls.bgTop)
     LayoutHelpers.AnchorToTop(controls.bgStretch, controls.bgBottom)
     LayoutHelpers.AtRightIn(controls.bgStretch, controls.bgTop, 7)
-    
-	LayoutHelpers.SetDimensions(controls.container, 60, 20)
+
+    LayoutHelpers.SetDimensions(controls.container, 60, 20)
     LayoutHelpers.AtTopIn(controls.container, controls.parent, 368)
     LayoutHelpers.AtRightIn(controls.container, controls.parent)
-    
+
     LayoutHelpers.AtTopIn(controls.collapseArrow, controls.container, 22)
     LayoutHelpers.AtRightIn(controls.collapseArrow, controls.parent, -3)
-    
-    controls.collapseArrow.Depth:Set(function() return controls.bgTop.Depth() + 1 end)
+
+    LayoutHelpers.DepthOverParent(controls.collapseArrow, controls.bgTop)
     controls.collapseArrow:SetTexture(UIUtil.UIFile('/game/tab-r-btn/tab-close_btn_up.dds'))
     controls.collapseArrow:SetNewTextures(UIUtil.UIFile('/game/tab-r-btn/tab-close_btn_up.dds'),
         UIUtil.UIFile('/game/tab-r-btn/tab-open_btn_up.dds'),
@@ -55,7 +55,7 @@ function LayoutGroups()
         end
         prevControl = control
     end
-    if controls.groups and table.getsize(controls.groups) > 0 then
+    if controls.groups and not table.empty(controls.groups) then
         controls.container.Bottom:Set(prevControl.Bottom)
         controls.container:Show()
         controls.collapseArrow:Show()

--- a/gamedata/lua/lua/ui/game/layouts/economy_mini.lua
+++ b/gamedata/lua/lua/ui/game/layouts/economy_mini.lua
@@ -1,11 +1,11 @@
 
-local UIUtil = import('/lua/ui/uiutil.lua')
-local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
-local Group = import('/lua/maui/group.lua').Group
-local Bitmap = import('/lua/maui/bitmap.lua').Bitmap
-local Button = import('/lua/maui/button.lua').Button
-local StatusBar = import('/lua/maui/statusbar.lua').StatusBar
-local parent = import('/lua/ui/game/economy.lua').savedParent
+local UIUtil = import("/lua/ui/uiutil.lua")
+local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
+local Group = import("/lua/maui/group.lua").Group
+local Bitmap = import("/lua/maui/bitmap.lua").Bitmap
+local Button = import("/lua/maui/button.lua").Button
+local StatusBar = import("/lua/maui/statusbar.lua").StatusBar
+local parent = import("/lua/ui/game/economy.lua").savedParent
 
 local style = {
     mass = {
@@ -23,8 +23,8 @@ local style = {
 }
 
 function SetLayout()
-    local GUI = import('/lua/ui/game/economy.lua').GUI
-    local parent = import('/lua/ui/game/economy.lua').savedParent
+    local GUI = import("/lua/ui/game/economy.lua").GUI
+    local parent = import("/lua/ui/game/economy.lua").savedParent
 
     GUI.collapseArrow:SetTexture(UIUtil.UIFile('/game/tab-l-btn/tab-close_btn_up.dds'))
     GUI.collapseArrow:SetNewTextures(UIUtil.UIFile('/game/tab-l-btn/tab-close_btn_up.dds'),
@@ -51,7 +51,7 @@ function SetLayout()
     LayoutHelpers.AtLeftIn(GUI.bg.leftBracketGlow, GUI.bg.leftBracket, 12)
 
     GUI.bg.leftBracket.Depth:Set(GUI.bg.panel.Depth)
-    GUI.bg.leftBracketGlow.Depth:Set(function() return GUI.bg.leftBracket.Depth() - 1 end)
+    LayoutHelpers.DepthUnderParent(GUI.bg.leftBracketGlow, GUI.bg.leftBracket)
 
     LayoutHelpers.AtVerticalCenterIn(GUI.bg.leftBracket, GUI.bg.panel)
     LayoutHelpers.AtVerticalCenterIn(GUI.bg.leftBracketGlow, GUI.bg.panel)
@@ -66,7 +66,7 @@ function SetLayout()
     GUI.bg.rightGlowBottom.Left:Set(GUI.bg.rightGlowTop.Left)
     GUI.bg.rightGlowMiddle.Top:Set(GUI.bg.rightGlowTop.Bottom)
     GUI.bg.rightGlowMiddle.Bottom:Set(function() return math.max(GUI.bg.rightGlowTop.Bottom(), GUI.bg.rightGlowBottom.Top()) end)
-    GUI.bg.rightGlowMiddle.Right:Set(GUI.bg.rightGlowTop.Right)
+    GUI.bg.rightGlowMiddle.Right:Set(function() return GUI.bg.rightGlowTop.Right() end)
 
     LayoutResourceGroup(GUI.mass, 'mass')
     LayoutResourceGroup(GUI.energy, 'energy')
@@ -138,8 +138,8 @@ function LayoutResourceGroup(group, groupType)
 end
 
 function TogglePanelAnimation(state)
-    local GUI = import('/lua/ui/game/economy.lua').GUI
-    local savedParent = import('/lua/ui/game/economy.lua').savedParent
+    local GUI = import("/lua/ui/game/economy.lua").GUI
+    local savedParent = import("/lua/ui/game/economy.lua").savedParent
     if UIUtil.GetAnimationPrefs() then
         if state or GUI.bg:IsHidden() then
             PlaySound(Sound({Cue = "UI_Score_Window_Open", Bank = "Interface"}))
@@ -180,8 +180,8 @@ function TogglePanelAnimation(state)
 end
 
 function InitAnimation()
-    local GUI = import('/lua/ui/game/economy.lua').GUI
-    local savedParent = import('/lua/ui/game/economy.lua').savedParent
+    local GUI = import("/lua/ui/game/economy.lua").GUI
+    local savedParent = import("/lua/ui/game/economy.lua").savedParent
     GUI.bg:Show()
     GUI.bg.Left:Set(savedParent.Left()-GUI.bg.Width())
     GUI.bg:SetNeedsFrameUpdate(true)

--- a/gamedata/lua/lua/ui/game/layouts/minimap_mini.lua
+++ b/gamedata/lua/lua/ui/game/layouts/minimap_mini.lua
@@ -1,11 +1,9 @@
-
 local UIUtil = import('/lua/ui/uiutil.lua')
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
-local Prefs = import('/lua/user/prefs.lua')
 
 function SetLayout()
     local controls = import('/lua/ui/game/minimap.lua').controls
-    
+
     local windowTextures = {
         tl = UIUtil.UIFile('/game/mini-map-brd/mini-map_brd_ul.dds'),
         tr = UIUtil.UIFile('/game/mini-map-brd/mini-map_brd_ur.dds'),
@@ -18,9 +16,9 @@ function SetLayout()
         br = UIUtil.UIFile('/game/mini-map-brd/mini-map_brd_lr.dds'),
         borderColor = 'ff415055',
     }
-    
+
     controls.displayGroup:ApplyWindowTextures(windowTextures)
-    
+
     controls.miniMap.GlowTL:SetTexture(UIUtil.UIFile('/game/mini-map-glow-brd/mini-map-glow_brd_ul.dds'))
     controls.miniMap.GlowTR:SetTexture(UIUtil.UIFile('/game/mini-map-glow-brd/mini-map-glow_brd_ur.dds'))
     controls.miniMap.GlowBR:SetTexture(UIUtil.UIFile('/game/mini-map-glow-brd/mini-map-glow_brd_lr.dds'))
@@ -29,93 +27,84 @@ function SetLayout()
     controls.miniMap.GlowR:SetTexture(UIUtil.UIFile('/game/mini-map-glow-brd/mini-map-glow_brd_vert_r.dds'))
     controls.miniMap.GlowT:SetTexture(UIUtil.UIFile('/game/mini-map-glow-brd/mini-map-glow_brd_horz_um.dds'))
     controls.miniMap.GlowB:SetTexture(UIUtil.UIFile('/game/mini-map-glow-brd/mini-map-glow_brd_lm.dds'))
-    
+
     controls.miniMap.DragTL:SetTexture(UIUtil.UIFile('/game/drag-handle/drag-handle-ul_btn_up.dds'))
     controls.miniMap.DragTR:SetTexture(UIUtil.UIFile('/game/drag-handle/drag-handle-ur_btn_up.dds'))
     controls.miniMap.DragBL:SetTexture(UIUtil.UIFile('/game/drag-handle/drag-handle-ll_btn_up.dds'))
     controls.miniMap.DragBR:SetTexture(UIUtil.UIFile('/game/drag-handle/drag-handle-lr_btn_up.dds'))
-    
+
     controls.miniMap.DragTL.textures = {up = UIUtil.UIFile('/game/drag-handle/drag-handle-ul_btn_up.dds'),
             down = UIUtil.UIFile('/game/drag-handle/drag-handle-ul_btn_down.dds'),
             over = UIUtil.UIFile('/game/drag-handle/drag-handle-ul_btn_over.dds')}
-            
+
     controls.miniMap.DragTR.textures = {up = UIUtil.UIFile('/game/drag-handle/drag-handle-ur_btn_up.dds'),
             down = UIUtil.UIFile('/game/drag-handle/drag-handle-ur_btn_down.dds'),
             over = UIUtil.UIFile('/game/drag-handle/drag-handle-ur_btn_over.dds')}
-            
+
     controls.miniMap.DragBL.textures = {up = UIUtil.UIFile('/game/drag-handle/drag-handle-ll_btn_up.dds'),
             down = UIUtil.UIFile('/game/drag-handle/drag-handle-ll_btn_down.dds'),
             over = UIUtil.UIFile('/game/drag-handle/drag-handle-ll_btn_over.dds')}
-            
+
     controls.miniMap.DragBR.textures = {up = UIUtil.UIFile('/game/drag-handle/drag-handle-lr_btn_up.dds'),
             down = UIUtil.UIFile('/game/drag-handle/drag-handle-lr_btn_down.dds'),
             over = UIUtil.UIFile('/game/drag-handle/drag-handle-lr_btn_over.dds')}
-    
-    controls.miniMap.GlowTL.Top:Set(function() return controls.displayGroup:GetClientGroup().Top() - 4 end)
-    controls.miniMap.GlowTL.Left:Set(function() return controls.displayGroup:GetClientGroup().Left() - 0 end)
+
+    local clientGroup = controls.displayGroup:GetClientGroup()
+    LayoutHelpers.AtLeftTopIn(controls.miniMap.GlowTL, clientGroup, 0, -4)
     controls.miniMap.GlowTL:SetRenderPass(UIUtil.UIRP_PostGlow)
     controls.miniMap.GlowTL:DisableHitTest()
-    
-    controls.miniMap.GlowTR.Top:Set(function() return controls.displayGroup:GetClientGroup().Top() - 4 end)
-    controls.miniMap.GlowTR.Right:Set(function() return controls.displayGroup:GetClientGroup().Right() - 0 end)
+
+    LayoutHelpers.AtRightTopIn(controls.miniMap.GlowTR, clientGroup, 0, -4)
     controls.miniMap.GlowTR:SetRenderPass(UIUtil.UIRP_PostGlow)
     controls.miniMap.GlowTR:DisableHitTest()
-    controls.miniMap.GlowBR.Bottom:Set(function() return controls.displayGroup:GetClientGroup().Bottom() + 2 end)
-    controls.miniMap.GlowBR.Right:Set(function() return controls.displayGroup:GetClientGroup().Right() - 0 end)
+    LayoutHelpers.AtRightBottomIn(controls.miniMap.GlowBR, clientGroup, 0, -2)
     controls.miniMap.GlowBR:SetRenderPass(UIUtil.UIRP_PostGlow)
     controls.miniMap.GlowBR:DisableHitTest()
-    controls.miniMap.GlowBL.Bottom:Set(function() return controls.displayGroup:GetClientGroup().Bottom() + 2 end)
-    controls.miniMap.GlowBL.Left:Set(function() return controls.displayGroup:GetClientGroup().Left() + 0 end)
+    LayoutHelpers.AtLeftBottomIn(controls.miniMap.GlowBL, clientGroup, 0, -2)
     controls.miniMap.GlowBL:SetRenderPass(UIUtil.UIRP_PostGlow)
     controls.miniMap.GlowBL:DisableHitTest()
-    controls.miniMap.GlowL.Left:Set(function() return controls.miniMap.GlowTL.Left() + 2 end)
+    LayoutHelpers.AtLeftIn(controls.miniMap.GlowL, controls.miniMap.GlowTL, 2)
     controls.miniMap.GlowL.Top:Set(controls.miniMap.GlowTL.Bottom)
     controls.miniMap.GlowL.Bottom:Set(controls.miniMap.GlowBL.Top)
     controls.miniMap.GlowL:SetRenderPass(UIUtil.UIRP_PostGlow)
     controls.miniMap.GlowL:DisableHitTest()
-    controls.miniMap.GlowR.Right:Set(function() return controls.miniMap.GlowTR.Right() - 2 end)
+    LayoutHelpers.AtRightIn(controls.miniMap.GlowR, controls.miniMap.GlowTR, 2)
     controls.miniMap.GlowR.Top:Set(controls.miniMap.GlowTR.Bottom)
     controls.miniMap.GlowR.Bottom:Set(controls.miniMap.GlowBR.Top)
     controls.miniMap.GlowR:SetRenderPass(UIUtil.UIRP_PostGlow)
     controls.miniMap.GlowR:DisableHitTest()
     controls.miniMap.GlowT.Right:Set(controls.miniMap.GlowTR.Left)
     controls.miniMap.GlowT.Left:Set(controls.miniMap.GlowTL.Right)
-    controls.miniMap.GlowT.Top:Set(function() return controls.miniMap.GlowTL.Top() + 1 end)
+    LayoutHelpers.AtTopIn(controls.miniMap.GlowT, controls.miniMap.GlowTL, 1)
     controls.miniMap.GlowT:SetRenderPass(UIUtil.UIRP_PostGlow)
     controls.miniMap.GlowT:DisableHitTest()
     controls.miniMap.GlowB.Right:Set(controls.miniMap.GlowBR.Left)
     controls.miniMap.GlowB.Left:Set(controls.miniMap.GlowBL.Right)
-    controls.miniMap.GlowB.Bottom:Set(function() return controls.miniMap.GlowBL.Bottom() - 1 end)
+    LayoutHelpers.AtBottomIn(controls.miniMap.GlowB, controls.miniMap.GlowBL, 1)
     controls.miniMap.GlowB:SetRenderPass(UIUtil.UIRP_PostGlow)
     controls.miniMap.GlowB:DisableHitTest()
-    
-    controls.miniMap.DragTL.Left:Set(function() return controls.displayGroup.Left() - 27 end)
-    controls.miniMap.DragTL.Top:Set(function() return controls.displayGroup.Top() - 10 end)
+
+    LayoutHelpers.AtLeftTopIn(controls.miniMap.DragTL, controls.displayGroup, -27, -10)
     controls.miniMap.DragTL:SetRenderPass(UIUtil.UIRP_PostGlow)
     controls.miniMap.DragTL:DisableHitTest()
-    
-    controls.miniMap.DragTR.Right:Set(function() return controls.displayGroup.Right() + 22 end)
-    controls.miniMap.DragTR.Top:Set(function() return controls.displayGroup.Top() - 10 end)
+
+    LayoutHelpers.AtRightTopIn(controls.miniMap.DragTR, controls.displayGroup, -22, -10)
     controls.miniMap.DragTR:SetRenderPass(UIUtil.UIRP_PostGlow)
     controls.miniMap.DragTR:DisableHitTest()
-    
-    controls.miniMap.DragBL.Left:Set(function() return controls.displayGroup.Left() - 27 end)
-    controls.miniMap.DragBL.Bottom:Set(function() return controls.displayGroup.Bottom() + 8 end)
+
+    LayoutHelpers.AtLeftBottomIn(controls.miniMap.DragBL, controls.displayGroup, -27, -8)
     controls.miniMap.DragBL:SetRenderPass(UIUtil.UIRP_PostGlow)
     controls.miniMap.DragBL:DisableHitTest()
-    
-    controls.miniMap.DragBR.Right:Set(function() return controls.displayGroup.Right() + 22 end)
-    controls.miniMap.DragBR.Bottom:Set(function() return controls.displayGroup.Bottom() + 8 end)
+
+    LayoutHelpers.AtRightBottomIn(controls.miniMap.DragBR, controls.displayGroup, -22, -8)
     controls.miniMap.DragBR:SetRenderPass(UIUtil.UIRP_PostGlow)
     controls.miniMap.DragBR:DisableHitTest()
-    
+
     controls.miniMap.DragTL.Depth:Set(function() return controls.displayGroup.Depth() + 2 end)
     controls.miniMap.DragTR.Depth:Set(controls.miniMap.DragTL.Depth)
     controls.miniMap.DragBL.Depth:Set(controls.miniMap.DragTL.Depth)
     controls.miniMap.DragBR.Depth:Set(controls.miniMap.DragTL.Depth)
-        
-    controls.miniMap.Left:Set(function() return controls.displayGroup:GetClientGroup().Left() + 8 end)
-    controls.miniMap.Top:Set(function() return controls.displayGroup:GetClientGroup().Top() + 4 end)
-    controls.miniMap.Right:Set(function() return controls.displayGroup:GetClientGroup().Right() - 8 end)
-    controls.miniMap.Bottom:Set(function() return controls.displayGroup:GetClientGroup().Bottom() - 6 end)
+
+    LayoutHelpers.AtLeftTopIn(controls.miniMap, clientGroup, 8, 4)
+    LayoutHelpers.AtRightBottomIn(controls.miniMap, clientGroup, 8, 6)
 end

--- a/gamedata/lua/lua/ui/game/layouts/multifunction_mini.lua
+++ b/gamedata/lua/lua/ui/game/layouts/multifunction_mini.lua
@@ -6,14 +6,14 @@ function SetLayout()
     local controls = import('/lua/ui/game/multifunction.lua').controls
     local savedParent = import('/lua/ui/game/multifunction.lua').savedParent
     local econControl = import('/lua/ui/game/economy.lua').GUI.bg
-    
+
     controls.bg.panel:SetTexture(UIUtil.UIFile('/game/filter-ping-panel/filter-ping-panel02_bmp.dds'))
     controls.bg.leftBrace:SetTexture(UIUtil.UIFile('/game/filter-ping-panel/bracket-left_bmp.dds'))
     controls.bg.leftGlow:SetTexture(UIUtil.UIFile('/game/filter-ping-panel/bracket-energy-l_bmp.dds'))
     controls.bg.rightGlowTop:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_t.dds'))
     controls.bg.rightGlowMiddle:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_m.dds'))
     controls.bg.rightGlowBottom:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_b.dds'))
-    
+
     controls.collapseArrow:SetTexture(UIUtil.UIFile('/game/tab-l-btn/tab-close_btn_up.dds'))
     controls.collapseArrow:SetNewTextures(UIUtil.UIFile('/game/tab-l-btn/tab-close_btn_up.dds'),
         UIUtil.UIFile('/game/tab-l-btn/tab-open_btn_up.dds'),
@@ -23,7 +23,7 @@ function SetLayout()
         UIUtil.UIFile('/game/tab-l-btn/tab-open_btn_dis.dds'))
     LayoutHelpers.AtLeftTopIn(controls.collapseArrow, GetFrame(0), -3, 97)
     controls.collapseArrow.Depth:Set(function() return controls.bg.Depth() + 10 end)
-    
+
     LayoutHelpers.Below(controls.bg, econControl, 5)
     if controls.collapseArrow:IsChecked() then
         LayoutHelpers.AtLeftIn(controls.bg, savedParent, -200)
@@ -32,22 +32,21 @@ function SetLayout()
     end
     controls.bg.Height:Set(controls.bg.panel.Height)
     controls.bg.Width:Set(controls.bg.panel.Width)
-    
+
     LayoutHelpers.AtLeftTopIn(controls.bg.panel, controls.bg, 2)
-	LayoutHelpers.AnchorToLeft(controls.bg.leftBrace, controls.bg, -11)
-	LayoutHelpers.AtTopIn(controls.bg.leftBrace, controls.bg, 2)
-	LayoutHelpers.AtLeftIn(controls.bg.leftGlow, controls.bg.leftBrace, 12)
-	LayoutHelpers.AtTopIn(controls.bg.leftGlow, controls.bg)
+    LayoutHelpers.AnchorToLeft(controls.bg.leftBrace, controls.bg, -11)
+    LayoutHelpers.AtTopIn(controls.bg.leftBrace, controls.bg, 2)
+    LayoutHelpers.AtLeftIn(controls.bg.leftGlow, controls.bg.leftBrace, 12)
+    LayoutHelpers.AtTopIn(controls.bg.leftGlow, controls.bg)
     controls.bg.leftGlow.Depth:Set(function() return controls.bg.leftBrace.Depth() - 1 end)
-	LayoutHelpers.AtTopIn(controls.bg.rightGlowTop, controls.bg, 3)
-	LayoutHelpers.AnchorToRight(controls.bg.rightGlowTop, controls.bg, -9)
-	LayoutHelpers.AtBottomIn(controls.bg.rightGlowBottom, controls.bg, 3)
+    LayoutHelpers.AtTopIn(controls.bg.rightGlowTop, controls.bg, 3)
+    LayoutHelpers.AnchorToRight(controls.bg.rightGlowTop, controls.bg, -9)
+    LayoutHelpers.AtBottomIn(controls.bg.rightGlowBottom, controls.bg, 3)
     controls.bg.rightGlowBottom.Left:Set(controls.bg.rightGlowTop.Left)
     controls.bg.rightGlowMiddle.Top:Set(controls.bg.rightGlowTop.Bottom)
     controls.bg.rightGlowMiddle.Bottom:Set(function() return math.max(controls.bg.rightGlowTop.Bottom(), controls.bg.rightGlowBottom.Top()) end)
-	LayoutHelpers.AtRightIn(controls.bg.rightGlowMiddle, controls.bg.rightGlowTop)
-    
-    
+    controls.bg.rightGlowMiddle.Right:Set(controls.bg.rightGlowTop.Right)
+
     for i, control in controls.overlayBtns do
         local index = i
         if index == 1 then
@@ -60,7 +59,7 @@ function SetLayout()
             LayoutHelpers.AtVerticalCenterIn(control.dropout, control, -1)
         end
     end
-    
+
     for i, control in controls.pingBtns do
         local index = i
         if index == 1 then
@@ -69,5 +68,5 @@ function SetLayout()
             LayoutHelpers.RightOf(control, controls.pingBtns[index-1], -7)
         end
     end
-    
+
 end

--- a/gamedata/lua/lua/ui/game/layouts/objectives2_mini.lua
+++ b/gamedata/lua/lua/ui/game/layouts/objectives2_mini.lua
@@ -22,51 +22,49 @@ local textures = {
 
 function SetLayout()
     local controls = import('/lua/ui/game/objectives2.lua').controls
-    
+
     LayoutHelpers.AtRightTopIn(controls.bg, controls.parent)
-    
+
     LayoutHelpers.AtRightTopIn(controls.infoContainer, controls.bg, 13, 10)
     controls.infoContainer.Height:Set(controls.infoContainer.LeftBG.Height)
-    controls.infoContainer.Width:Set(function() return controls.time.Width() + controls.units.Width() + 120 end)
-    
+    controls.infoContainer.Width:Set(function() return controls.time.Width() + controls.units.Width() + LayoutHelpers.ScaleNumber(120) end)
+
     controls.objectiveContainer.Top:Set(function() return controls.infoContainer.Bottom() end)
     LayoutHelpers.AtRightIn(controls.objectiveContainer, controls.bg, 15)
     controls.objectiveContainer.Height:Set(controls.objectiveContainer.LeftBG.Height)
-    controls.objectiveContainer.Width:Set(1)
-    
+    LayoutHelpers.SetWidth(controls.objectiveContainer, 1)
+
     controls.squadContainer.Top:Set(function() return controls.objectiveContainer.Bottom() end)
     LayoutHelpers.AtRightIn(controls.squadContainer, controls.bg, 15)
     controls.squadContainer.Height:Set(controls.squadContainer.LeftBG.Height)
-    controls.squadContainer.Width:Set(1)
-    
+    LayoutHelpers.SetWidth(controls.squadContainer, 1)
+
     controls.timeIcon:SetTexture(UIUtil.UIFile('/game/unit_view_icons/time.dds'))
     controls.unitIcon:SetTexture(UIUtil.UIFile('/dialogs/score-overlay/tank_bmp.dds'))
     LayoutHelpers.AtLeftTopIn(controls.timeIcon, controls.infoContainer, 20, 2)
     LayoutHelpers.AtRightTopIn(controls.unitIcon, controls.infoContainer, 20, 2)
     LayoutHelpers.RightOf(controls.time, controls.timeIcon, 2)
     LayoutHelpers.LeftOf(controls.units, controls.unitIcon)
-    
-    controls.timeIcon.Height:Set(function() return controls.timeIcon.BitmapHeight() * .9 end)
-    controls.timeIcon.Width:Set(function() return controls.timeIcon.BitmapWidth() * .9 end)
-    controls.unitIcon.Height:Set(function() return controls.unitIcon.BitmapHeight() * .9 end)
-    controls.unitIcon.Width:Set(function() return controls.unitIcon.BitmapWidth() * .9 end)
-    
+
+    LayoutHelpers.SetDimensions(controls.timeIcon, controls.timeIcon.BitmapWidth() * .9, controls.timeIcon.BitmapHeight() * .9)
+    LayoutHelpers.SetDimensions(controls.unitIcon, controls.unitIcon.BitmapWidth() * .9, controls.unitIcon.BitmapHeight() * .9)
+
     LayoutContainerBG(controls.objectiveContainer, textures.objective)
     LayoutContainerBG(controls.squadContainer, textures.squad)
     LayoutContainerBG(controls.infoContainer, textures.info)
-    
+
     controls.bg.bracketTop:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_t.dds'))
     controls.bg.bracketBottom:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_b.dds'))
     controls.bg.bracketStretch:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_m.dds'))
-    
+
     LayoutHelpers.AtRightTopIn(controls.bg.bracketTop, controls.bg)
     controls.bg.bracketBottom.Top:Set(function() return math.max(controls.bg.Bottom() - controls.bg.bracketBottom.Height(), controls.bg.bracketTop.Bottom()) end)
     LayoutHelpers.AtRightIn(controls.bg.bracketBottom, controls.bg)
-    
+
     controls.bg.bracketStretch.Top:Set(controls.bg.bracketTop.Bottom)
-    controls.bg.bracketStretch.Right:Set(function() return controls.bg.bracketTop.Right() - 7 end)
+    LayoutHelpers.AtRightIn(controls.bg.bracketStretch, controls.bg.bracketTop, 7)
     controls.bg.bracketStretch.Bottom:Set(controls.bg.bracketBottom.Top)
-    
+
     LayoutHelpers.AtTopIn(controls.collapseArrow, controls.bg, 22)
     LayoutHelpers.AtRightIn(controls.collapseArrow, controls.parent, -3)
     controls.collapseArrow.Depth:Set(function() return controls.bg.Depth() + 10 end)
@@ -77,8 +75,8 @@ function SetLayout()
         UIUtil.UIFile('/game/tab-r-btn/tab-open_btn_over.dds'),
         UIUtil.UIFile('/game/tab-r-btn/tab-close_btn_dis.dds'),
         UIUtil.UIFile('/game/tab-r-btn/tab-open_btn_dis.dds'))
-        
-    controls.bg.Height:Set(function() 
+
+    controls.bg.Height:Set(function()
         local height = 0
         if not controls.infoContainer:IsHidden() then
             height = height + controls.infoContainer.Height()
@@ -89,28 +87,28 @@ function SetLayout()
         if not controls.squadContainer:IsHidden() then
             height = height + controls.squadContainer.Height()
         end
-        return height + 20
+        return height + LayoutHelpers.ScaleNumber(20)
     end)
     controls.bg.Width:Set(function() return math.max(math.max(controls.infoContainer.Width(), controls.objectiveContainer.Width()), controls.squadContainer.Width()) end)
-    
+
     local avatarGroup = import('/lua/ui/game/avatars.lua').controls.avatarGroup
-    avatarGroup.Top:Set(controls.bg.bracketBottom.Bottom()+60)
+    LayoutHelpers.AnchorToBottom(avatarGroup, controls.bg.bracketBottom, 60)
 end
 
 function LayoutContainerBG(container, textures)
     container.LeftBG:SetTexture(UIUtil.UIFile('/game/pda-panel/'..textures.left))
     container.RightBG:SetTexture(UIUtil.UIFile('/game/pda-panel/'..textures.right))
     container.StretchBG:SetTexture(UIUtil.UIFile('/game/pda-panel/'..textures.middle))
-    
+
     container.LeftBG.Depth:Set(container.Depth)
     container.RightBG.Depth:Set(container.Depth)
     container.StretchBG.Depth:Set(container.Depth)
 
     LayoutHelpers.AtRightTopIn(container.RightBG, container)
-    
+
     container.LeftBG.Right:Set(function() return math.min(container.RightBG.Left(), container.Left() + container.LeftBG.Width()) end)
-    container.LeftBG.Top:Set(function() return container.RightBG.Top() - 2 end)
-    
+    LayoutHelpers.AtTopIn(container.LeftBG, container.RightBG, -2)
+
     container.StretchBG.Top:Set(container.RightBG.Top)
     container.StretchBG.Left:Set(container.LeftBG.Right)
     container.StretchBG.Right:Set(container.RightBG.Left)

--- a/gamedata/lua/lua/ui/game/layouts/orders_left.lua
+++ b/gamedata/lua/lua/ui/game/layouts/orders_left.lua
@@ -1,3 +1,4 @@
+
 local UIUtil = import('/lua/ui/uiutil.lua')
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 local GameCommon = import('/lua/ui/game/gamecommon.lua')
@@ -12,73 +13,58 @@ local vertCols = Grid_Params.Grid.vertCols
 local horzCols = Grid_Params.Grid.horzCols
 
 function SetLayout()
-
     local controls = import('/lua/ui/game/orders.lua').controls
-    
-    controls.bg:SetTexture(UIUtil.UIFile('/game/orders-panel_vert/order-panel_bmp.dds'))
 
+    controls.bg:SetTexture(UIUtil.UIFile('/game/orders-panel_vert/order-panel_bmp.dds'))
     LayoutHelpers.AtLeftIn(controls.bg, controls.controlClusterGroup, 17)
     LayoutHelpers.AtTopIn(controls.bg, controls.controlClusterGroup, 0)
     LayoutHelpers.ResetRight(controls.bg)
     LayoutHelpers.ResetBottom(controls.bg)
-    
-    controls.bracket:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_t.dds'))
 
+    controls.bracket:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_t.dds'))
     LayoutHelpers.AtLeftIn(controls.bracket, controls.bg, -17)
     LayoutHelpers.AtTopIn(controls.bracket, controls.bg, -2)
     LayoutHelpers.ResetBottom(controls.bracket)
     LayoutHelpers.ResetRight(controls.bracket)
-    
-    controls.bracketMax:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_b.dds'))
 
+    controls.bracketMax:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_b.dds'))
     LayoutHelpers.AtLeftIn(controls.bracketMax, controls.bracket)
     LayoutHelpers.AtBottomIn(controls.bracketMax, controls.bg, 2)
-    
+
     controls.bracketMid:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_m.dds'))
-
     LayoutHelpers.AtLeftIn(controls.bracketMid, controls.bracket)
-
     controls.bracketMid.Top:Set(controls.bracket.Bottom)
     controls.bracketMid.Bottom:Set(controls.bracketMax.Top)
-    
+
     if controls.bracketRightMin then
         controls.bracketRightMin:Destroy()
         controls.bracketRightMax:Destroy()
         controls.bracketRightMid:Destroy()
-        
+
         controls.bracketRightMin = nil
         controls.bracketRightMax = nil
         controls.bracketRightMid = nil
     end
-    
-    controls.bracketMax:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_b.dds'))
 
+    controls.bracketMax:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_b.dds'))
     LayoutHelpers.AtLeftIn(controls.bracketMax, controls.bracket)
     LayoutHelpers.AtBottomIn(controls.bracketMax, controls.bg, -2)
-    
+
     controls.bracketMid:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_m.dds'))
-
     LayoutHelpers.AtLeftIn(controls.bracketMid, controls.bracket, 7)
-
     controls.bracketMid.Top:Set(controls.bracket.Bottom)
     controls.bracketMid.Bottom:Set(controls.bracketMax.Top)
-    
-    controls.orderButtonGrid.Width:Set(GameCommon.iconWidth * horzCols)
-    controls.orderButtonGrid.Height:Set(GameCommon.iconHeight * horzRows)
 
+    LayoutHelpers.SetDimensions(controls.orderButtonGrid, GameCommon.iconWidth * horzCols, GameCommon.iconHeight * horzRows)
     LayoutHelpers.AtCenterIn(controls.orderButtonGrid, controls.bg, 0, -1)
-
     controls.orderButtonGrid:AppendRows(horzRows)
     controls.orderButtonGrid:AppendCols(horzCols)
 
-	controls.bg.Width:Set(Grid_Params.Order_Slots.panelsize.width)
-	controls.bg.Height:Set(Grid_Params.Order_Slots.panelsize.height)
+    controls.bg.Width:Set(Grid_Params.Order_Slots.panelsize.width)
+    controls.bg.Height:Set(Grid_Params.Order_Slots.panelsize.height)
+    LayoutHelpers.SetDimensions(controls.orderButtonGrid, Grid_Params.Order_Slots.iconsize.width * Grid_Params.Grid.horzCols, Grid_Params.Order_Slots.iconsize.height * Grid_Params.Grid.horzRows)
+    LayoutHelpers.AtLeftTopIn(controls.orderButtonGrid, controls.bg, 10, 12)
 
-	controls.orderButtonGrid.Width:Set(Grid_Params.Order_Slots.iconsize.width * Grid_Params.Grid.horzCols)
-	controls.orderButtonGrid.Height:Set(Grid_Params.Order_Slots.iconsize.height * Grid_Params.Grid.horzRows)
-
-	LayoutHelpers.AtLeftTopIn(controls.orderButtonGrid, controls.bg, 10, 9)
-    
     controls.bg.Mini = function(state)
         controls.bg:SetHidden(state)
         controls.orderButtonGrid:SetHidden(state)

--- a/gamedata/lua/lua/ui/game/layouts/orders_mini.lua
+++ b/gamedata/lua/lua/ui/game/layouts/orders_mini.lua
@@ -13,49 +13,48 @@ local vertCols = Grid_Params.Grid.vertCols
 local horzCols = Grid_Params.Grid.horzCols
 
 function SetLayout()
-
     local controls = import('/lua/ui/game/orders.lua').controls
-    
+
     controls.bg:SetTexture(UIUtil.SkinnableFile('/game/orders-panel/order-panel_bmp.dds'))
     LayoutHelpers.AtLeftIn(controls.bg, controls.controlClusterGroup, 17)
     LayoutHelpers.AtBottomIn(controls.bg, controls.controlClusterGroup)
     LayoutHelpers.ResetRight(controls.bg)
     LayoutHelpers.ResetTop(controls.bg)
-    
+
     controls.bracket:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_t.dds'))
     LayoutHelpers.AtLeftIn(controls.bracket, controls.bg, -17)
     LayoutHelpers.AtTopIn(controls.bracket, controls.bg, -2)
     LayoutHelpers.ResetBottom(controls.bracket)
     LayoutHelpers.ResetRight(controls.bracket)
-    
+
     controls.bracketMax:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_b.dds'))
     LayoutHelpers.AtLeftIn(controls.bracketMax, controls.bracket)
     LayoutHelpers.AtBottomIn(controls.bracketMax, controls.bg, -2)
-    
+
     controls.bracketMid:SetTexture(UIUtil.UIFile('/game/bracket-left/bracket_bmp_m.dds'))
     LayoutHelpers.AtLeftIn(controls.bracketMid, controls.bracket, 7)
     controls.bracketMid.Top:Set(controls.bracket.Bottom)
     controls.bracketMid.Bottom:Set(controls.bracketMax.Top)
-    
+
     if controls.bracketRightMin then
         controls.bracketRightMin:Destroy()
         controls.bracketRightMax:Destroy()
         controls.bracketRightMid:Destroy()
-        
+
         controls.bracketRightMin = nil
         controls.bracketRightMax = nil
         controls.bracketRightMid = nil
     end
-    
+
     LayoutHelpers.SetDimensions(controls.orderButtonGrid, GameCommon.iconWidth * horzCols, GameCommon.iconHeight * horzRows)
     LayoutHelpers.AtCenterIn(controls.orderButtonGrid, controls.bg, 0, -1)
     controls.orderButtonGrid:AppendRows(horzRows)
     controls.orderButtonGrid:AppendCols(horzCols)
 
-	controls.bg.Width:Set(Grid_Params.Order_Slots.panelsize.width)
-	controls.bg.Height:Set(Grid_Params.Order_Slots.panelsize.height)
-	LayoutHelpers.SetDimensions(controls.orderButtonGrid, Grid_Params.Order_Slots.iconsize.width * Grid_Params.Grid.horzCols, Grid_Params.Order_Slots.iconsize.height * Grid_Params.Grid.horzRows)
-	LayoutHelpers.AtLeftTopIn(controls.orderButtonGrid, controls.bg, 10, 12)    
+    controls.bg.Width:Set(Grid_Params.Order_Slots.panelsize.width)
+    controls.bg.Height:Set(Grid_Params.Order_Slots.panelsize.height)
+    LayoutHelpers.SetDimensions(controls.orderButtonGrid, Grid_Params.Order_Slots.iconsize.width * Grid_Params.Grid.horzCols, Grid_Params.Order_Slots.iconsize.height * Grid_Params.Grid.horzRows)
+    LayoutHelpers.AtLeftTopIn(controls.orderButtonGrid, controls.bg, 10, 12)
 
     controls.bg.Mini = function(state)
         controls.bg:SetHidden(state)

--- a/gamedata/lua/lua/ui/game/layouts/orders_right.lua
+++ b/gamedata/lua/lua/ui/game/layouts/orders_right.lua
@@ -13,30 +13,29 @@ local vertCols = Grid_Params.Grid.vertCols
 local horzCols = Grid_Params.Grid.horzCols
 
 function SetLayout()
-
     local controls = import('/lua/ui/game/orders.lua').controls
-    
+
     controls.bg:SetTexture(UIUtil.SkinnableFile('/game/orders-panel/order-panel_bmp.dds'))
     LayoutHelpers.AtRightIn(controls.bg, controls.controlClusterGroup, 10)
     LayoutHelpers.AtBottomIn(controls.bg, controls.controlClusterGroup)
     LayoutHelpers.ResetLeft(controls.bg)
     LayoutHelpers.ResetTop(controls.bg)
-    
+
     controls.bracket:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_t.dds'))
     LayoutHelpers.AtLeftIn(controls.bracket, controls.bg, -6)
     LayoutHelpers.AtTopIn(controls.bracket, controls.bg, 2)
     LayoutHelpers.ResetBottom(controls.bracket)
     LayoutHelpers.ResetRight(controls.bracket)
-    
+
     controls.bracketMax:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_b.dds'))
     LayoutHelpers.AtLeftIn(controls.bracketMax, controls.bracket)
     LayoutHelpers.AtBottomIn(controls.bracketMax, controls.bg, 2)
-    
+
     controls.bracketMid:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_m.dds'))
     LayoutHelpers.AtLeftIn(controls.bracketMid, controls.bracket)
     controls.bracketMid.Top:Set(controls.bracket.Bottom)
     controls.bracketMid.Bottom:Set(controls.bracketMax.Top)
-    
+
     if not controls.bracketRightMin then
         controls.bracketRightMin = Bitmap(controls.bg)
         controls.bracketRightMax = Bitmap(controls.bg)
@@ -45,32 +44,30 @@ function SetLayout()
         controls.bracketRightMax:DisableHitTest()
         controls.bracketRightMid:DisableHitTest()
     end
-    
+
     controls.bracketRightMin:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_t.dds'))
     controls.bracketRightMax:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_b.dds'))
     controls.bracketRightMid:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_m.dds'))
-    
+
     controls.bracketRightMin.Top:Set(controls.bg.Top)
-    controls.bracketRightMin.Right:Set(function() return controls.bg.Right() + 11 end)
-    
+    LayoutHelpers.AtRightIn(controls.bracketRightMin, controls.bg, -11)
+
     controls.bracketRightMax.Bottom:Set(controls.bg.Bottom)
     controls.bracketRightMax.Right:Set(controls.bracketRightMin.Right)
-    
+
     controls.bracketRightMid.Bottom:Set(controls.bracketRightMax.Top)
     controls.bracketRightMid.Top:Set(controls.bracketRightMin.Bottom)
-    controls.bracketRightMid.Right:Set(function() return controls.bracketRightMin.Right() - 7 end)
-    
-    controls.orderButtonGrid.Width:Set(GameCommon.iconWidth * horzCols)
-    controls.orderButtonGrid.Height:Set(GameCommon.iconHeight * horzRows)
+    LayoutHelpers.AtRightIn(controls.bracketRightMid, controls.bracketRightMin, 7)
+
+    LayoutHelpers.SetDimensions(controls.orderButtonGrid, GameCommon.iconWidth * horzCols, GameCommon.iconHeight * horzRows)
     LayoutHelpers.AtCenterIn(controls.orderButtonGrid, controls.bg, 0, -1)
     controls.orderButtonGrid:AppendRows(horzRows)
     controls.orderButtonGrid:AppendCols(horzCols)
 
-	controls.bg.Width:Set(Grid_Params.Order_Slots.panelsize.width)
-	controls.bg.Height:Set(Grid_Params.Order_Slots.panelsize.height)
-	controls.orderButtonGrid.Width:Set(Grid_Params.Order_Slots.iconsize.width * Grid_Params.Grid.horzCols)
-	controls.orderButtonGrid.Height:Set(Grid_Params.Order_Slots.iconsize.height * Grid_Params.Grid.horzRows)
-	LayoutHelpers.AtLeftTopIn(controls.orderButtonGrid, controls.bg, 10, 12)    
+    controls.bg.Width:Set(Grid_Params.Order_Slots.panelsize.width)
+    controls.bg.Height:Set(Grid_Params.Order_Slots.panelsize.height)
+    LayoutHelpers.SetDimensions(controls.orderButtonGrid, Grid_Params.Order_Slots.iconsize.width * Grid_Params.Grid.horzCols, Grid_Params.Order_Slots.iconsize.height * Grid_Params.Grid.horzRows)
+    LayoutHelpers.AtLeftTopIn(controls.orderButtonGrid, controls.bg, 10, 12)
 
     controls.bg.Mini = function(state)
         controls.bg:SetHidden(state)

--- a/gamedata/lua/lua/ui/game/layouts/replay_mini.lua
+++ b/gamedata/lua/lua/ui/game/layouts/replay_mini.lua
@@ -26,25 +26,25 @@ end
 
 function SetLayout()
     CreateControls(import('/lua/ui/game/replay.lua').controls)
-    
+
     local controls = import('/lua/ui/game/replay.lua').controls
-    
+
     controls.bg:SetTexture(UIUtil.SkinnableFile('/game/replay/panel_bmp.dds'))
     LayoutHelpers.AtLeftIn(controls.bg, controls.controlClusterGroup, 6)
     LayoutHelpers.AtBottomIn(controls.bg, controls.controlClusterGroup, -3)
     LayoutHelpers.ResetRight(controls.bg)
     LayoutHelpers.ResetTop(controls.bg)
-    
+
     LayoutHelpers.AtLeftTopIn(controls.armycombo, controls.bg, 10, 10)
     LayoutHelpers.SetDimensions(controls.armycombo, 140, 20)
-    
+
     LayoutHelpers.AtLeftTopIn(controls.speedSlider, controls.bg, 10)
     LayoutHelpers.AtRightIn(controls.speedSlider, controls.bg, 40)
-    LayoutHelpers.AnchorToBottom(controls.speedSlider, controls.bg, 40)
+    LayoutHelpers.AnchorToBottom(controls.speedSlider, controls.bg, -40)
     controls.speedSlider._background.Left:Set(controls.speedSlider.Left)
     controls.speedSlider._background.Right:Set(controls.speedSlider.Right)
     controls.speedSlider._background.Top:Set(controls.speedSlider.Top)
     controls.speedSlider._background.Bottom:Set(controls.speedSlider.Bottom)
-    
+
     LayoutHelpers.RightOf(controls.currentSpeed, controls.speedSlider)
 end

--- a/gamedata/lua/lua/ui/game/layouts/score_mini.lua
+++ b/gamedata/lua/lua/ui/game/layouts/score_mini.lua
@@ -4,7 +4,7 @@ local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 function SetLayout()
     local controls = import('/lua/ui/game/score.lua').controls
     local mapGroup = import('/lua/ui/game/score.lua').savedParent
-    
+
     controls.collapseArrow:SetTexture(UIUtil.UIFile('/game/tab-r-btn/tab-close_btn_up.dds'))
     controls.collapseArrow:SetNewTextures(UIUtil.UIFile('/game/tab-r-btn/tab-close_btn_up.dds'),
         UIUtil.UIFile('/game/tab-r-btn/tab-open_btn_up.dds'),
@@ -14,50 +14,50 @@ function SetLayout()
         UIUtil.UIFile('/game/tab-r-btn/tab-open_btn_dis.dds'))
     LayoutHelpers.AtRightTopIn(controls.collapseArrow, mapGroup, -3, 21)
     controls.collapseArrow.Depth:Set(function() return controls.bg.Depth() + 10 end)
-    
+
     LayoutHelpers.AtRightTopIn(controls.bg, mapGroup, 18, 7)
     controls.bg.Width:Set(controls.bgTop.Width)
-    
+
     LayoutHelpers.AtRightTopIn(controls.bgTop, controls.bg, 3)
     LayoutHelpers.AtLeftTopIn(controls.armyGroup, controls.bgTop, 10, 25)
     controls.armyGroup.Width:Set(controls.armyLines[1].Width)
-    
+
     controls.leftBracketMin:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_t.dds'))
     LayoutHelpers.AtLeftTopIn(controls.leftBracketMin, controls.bg, -10, -1)
-    
+
     controls.leftBracketMax:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_b.dds'))
     LayoutHelpers.AtBottomIn(controls.leftBracketMax, controls.bg, -1)
     controls.leftBracketMax.Left:Set(controls.leftBracketMin.Left)
-    
+
     controls.leftBracketMid:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_m.dds'))
     controls.leftBracketMid.Top:Set(controls.leftBracketMin.Bottom)
     controls.leftBracketMid.Bottom:Set(controls.leftBracketMax.Top)
     controls.leftBracketMid.Left:Set(controls.leftBracketMin.Left)
-    
+
     controls.rightBracketMin:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_t.dds'))
     LayoutHelpers.AtRightTopIn(controls.rightBracketMin, controls.bg, -18, -5)
-    
+
     controls.rightBracketMax:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_b.dds'))
-    controls.rightBracketMax.Bottom:Set(function() 
+    controls.rightBracketMax.Bottom:Set(function()
             return math.max(controls.bg.Bottom() + LayoutHelpers.ScaleNumber(4), controls.rightBracketMin.Bottom() + controls.rightBracketMax.Height())
         end)
     controls.rightBracketMax.Right:Set(controls.rightBracketMin.Right)
-    
+
     controls.rightBracketMid:SetTexture(UIUtil.UIFile('/game/bracket-right/bracket_bmp_m.dds'))
     controls.rightBracketMid.Top:Set(controls.rightBracketMin.Bottom)
     controls.rightBracketMid.Bottom:Set(controls.rightBracketMax.Top)
     LayoutHelpers.AtRightIn(controls.rightBracketMid, controls.rightBracketMin, 7)
-    
+
     controls.bgTop:SetTexture(UIUtil.UIFile('/game/score-panel/panel-score_bmp_t.dds'))
     controls.bgBottom:SetTexture(UIUtil.UIFile('/game/score-panel/panel-score_bmp_b.dds'))
     controls.bgStretch:SetTexture(UIUtil.UIFile('/game/score-panel/panel-score_bmp_m.dds'))
-    
+
     controls.bgBottom.Top:Set(function() return math.max(controls.armyGroup.Bottom() - LayoutHelpers.ScaleNumber(14), controls.bgTop.Bottom()) end)
     controls.bgBottom.Right:Set(controls.bgTop.Right)
     controls.bgStretch.Top:Set(controls.bgTop.Bottom)
     controls.bgStretch.Bottom:Set(controls.bgBottom.Top)
     controls.bgStretch.Right:Set(controls.bgTop.Right)
-    
+
     controls.bg.Height:Set(function() return controls.bgBottom.Bottom() - controls.bgTop.Top() end)
     controls.armyGroup.Height:Set(function() 
         local totHeight = 0
@@ -66,27 +66,27 @@ function SetLayout()
         end
         return math.max(totHeight, LayoutHelpers.ScaleNumber(50))
     end)
-    
+
     LayoutHelpers.AtLeftTopIn(controls.timeIcon, controls.bgTop, 10, 6)
     controls.timeIcon:SetTexture(UIUtil.UIFile('/game/unit_view_icons/time.dds'))
     LayoutHelpers.RightOf(controls.time, controls.timeIcon)
-    
+
     LayoutHelpers.AtRightTopIn(controls.unitIcon, controls.bgTop, 10, 6)
     controls.unitIcon:SetTexture(UIUtil.UIFile('/dialogs/score-overlay/tank_bmp.dds'))
     LayoutHelpers.LeftOf(controls.units, controls.unitIcon)
-    
+
     LayoutHelpers.SetDimensions(controls.timeIcon, controls.timeIcon.BitmapWidth() * .8, controls.timeIcon.BitmapHeight() * .8)
     LayoutHelpers.SetDimensions(controls.unitIcon, controls.unitIcon.BitmapWidth() * .9, controls.unitIcon.BitmapHeight() * .9)
 
     local avatarGroup = import('/lua/ui/game/avatars.lua').controls.avatarGroup
     LayoutHelpers.AnchorToBottom(avatarGroup, controls.bgBottom, 4)
-    
+
     LayoutArmyLines()
 end
 
 function LayoutArmyLines()
     local controls = import('/lua/ui/game/score.lua').controls
-    
+
     for index, line in controls.armyLines do
         local i = index
         if i == 1 then
@@ -96,4 +96,3 @@ function LayoutArmyLines()
         end
     end
 end
-    

--- a/gamedata/lua/lua/ui/game/layouts/tabs_mini.lua
+++ b/gamedata/lua/lua/ui/game/layouts/tabs_mini.lua
@@ -3,7 +3,7 @@ local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 
 function SetLayout()
     local controls = import('/lua/ui/game/tabs.lua').controls
-    
+
     controls.collapseArrow:SetTexture(UIUtil.UIFile('/game/tab-t-btn/tab-close_btn_up.dds'))
     controls.collapseArrow:SetNewTextures(UIUtil.UIFile('/game/tab-t-btn/tab-close_btn_up.dds'),
         UIUtil.UIFile('/game/tab-t-btn/tab-open_btn_up.dds'),
@@ -14,25 +14,25 @@ function SetLayout()
     LayoutHelpers.AtTopIn(controls.collapseArrow, GetFrame(0), -3)
     LayoutHelpers.AtHorizontalCenterIn(controls.collapseArrow, controls.parent)
     controls.collapseArrow.Depth:Set(function() return controls.bgTop.Depth() + 10 end)
-    
+
     controls.bgTop.center:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_horz_um.dds'))
     controls.bgTop.left:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_ul.dds'))
     controls.bgTop.right:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_ur.dds'))
-    
+
     controls.bgTop.centerLeft:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_horz_uml.dds'))
     controls.bgTop.centerRight:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_horz_umr.dds'))
-    
+
     LayoutHelpers.AtTopIn(controls.bgTop, controls.parent)
     LayoutHelpers.AtHorizontalCenterIn(controls.bgTop, controls.parent)
-    
+
     controls.bgBottom.center:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_horz_lm.dds'))
     controls.bgBottom.left:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_ll.dds'))
     controls.bgBottom.right:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_lr.dds'))
     controls.bgBottom.Top:Set(controls.bgTop.Bottom)
     LayoutHelpers.AtHorizontalCenterIn(controls.bgBottom, controls.parent)
-    
+
     local containerWidth, containerHeight = 0, 0
-    
+
     for index, tab in controls.tabs do
         local i = index
         if i == 1 then
@@ -61,12 +61,12 @@ function SetLayout()
         containerWidth = containerWidth + tab.Width() - LayoutHelpers.ScaleNumber(4)
         containerHeight = math.max(containerHeight, tab.Height())
     end
-    
+
     controls.tabContainer.Width:Set(containerWidth)
     controls.tabContainer.Height:Set(containerHeight)
     LayoutHelpers.AtHorizontalCenterIn(controls.tabContainer, controls.parent)
     LayoutHelpers.AtTopIn(controls.tabContainer, controls.bgTop, 10)
-    
+
     controls.parent.Width:Set(controls.bgTop.Width)
     controls.parent.Height:Set(function() return controls.bgTop.Height() + controls.bgBottom.Height() end)
     LayoutHelpers.AtHorizontalCenterIn(controls.parent, GetFrame(0))
@@ -77,37 +77,37 @@ end
 
 function LayoutStretchBG()
     local controls = import('/lua/ui/game/tabs.lua').controls
-    
+
     controls.bgBottomLeftGlow:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_vert_ll.dds'))
     controls.bgBottomLeftGlow.Bottom:Set(controls.bgBottom.Top)
     controls.bgBottomLeftGlow.Left:Set(controls.bgBottom.Left)
     controls.bgBottomLeftGlow.Top:Set(function() return math.max(controls.bgTopLeftGlow.Bottom(), controls.bgBottomLeftGlow.Bottom() - controls.bgBottomLeftGlow.Height()) end)
-    
+
     controls.bgTopLeftGlow:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_vert_ul.dds'))
     controls.bgTopLeftGlow.Top:Set(controls.bgTop.Bottom)
     controls.bgTopLeftGlow.Left:Set(controls.bgTop.Left)
     controls.bgTopLeftGlow.Bottom:Set(function() return math.min(controls.bgBottom.Top(), controls.bgTop.Bottom() + controls.bgTopLeftGlow.Height()) end)
-    
+
     controls.bgLeftStretch:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_vert_l.dds'))
     controls.bgLeftStretch.Bottom:Set(controls.bgBottomLeftGlow.Top)
     LayoutHelpers.AtLeftIn(controls.bgLeftStretch, controls.bgTopLeftGlow, 4)
     controls.bgLeftStretch.Top:Set(controls.bgTopLeftGlow.Bottom)
-    
+
     controls.bgBottomRightGlow:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_vert_lr.dds'))
     controls.bgBottomRightGlow.Bottom:Set(controls.bgBottom.Top)
     controls.bgBottomRightGlow.Right:Set(controls.bgBottom.Right)
     controls.bgBottomRightGlow.Top:Set(function() return math.max(controls.bgTopRightGlow.Bottom(), controls.bgBottomRightGlow.Bottom() - controls.bgBottomRightGlow.Height()) end)
-    
+
     controls.bgTopRightGlow:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_vert_ur.dds'))
     controls.bgTopRightGlow.Top:Set(controls.bgTop.Bottom)
     controls.bgTopRightGlow.Right:Set(controls.bgTop.Right)
     controls.bgTopRightGlow.Bottom:Set(function() return math.min(controls.bgBottom.Top(), controls.bgTop.Bottom() + controls.bgTopRightGlow.Height()) end)
-    
+
     controls.bgRightStretch:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_vert_r.dds'))
     controls.bgRightStretch.Bottom:Set(controls.bgBottomRightGlow.Top)
     LayoutHelpers.AtRightIn(controls.bgRightStretch, controls.bgTopRightGlow, 4)
     controls.bgRightStretch.Top:Set(controls.bgTopRightGlow.Bottom)
-    
+
     controls.bgMidStretch:SetTexture(UIUtil.UIFile('/game/options-panel/options_brd_m.dds'))
     controls.bgMidStretch.Top:Set(controls.bgTop.Bottom)
     controls.bgMidStretch.Left:Set(controls.bgLeftStretch.Right)

--- a/gamedata/lua/lua/ui/game/layouts/unitviewDetail_left.lua
+++ b/gamedata/lua/lua/ui/game/layouts/unitviewDetail_left.lua
@@ -1,36 +1,32 @@
-
 local UIUtil = import('/lua/ui/uiutil.lua')
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 local Group = import('/lua/maui/group.lua').Group
 local Bitmap = import('/lua/maui/bitmap.lua').Bitmap
-local GameCommon = import('/lua/ui/game/gamecommon.lua')
-local ItemList = import('/lua/maui/itemlist.lua').ItemList
 local Prefs = import('/lua/user/prefs.lua')
-
 
 function CreateResourceGroup(parent, groupLabel)
     local group = Group(parent)
-    
-    # Group label
-    group.Label = UIUtil.CreateText( group, groupLabel, 12, "Arial Bold" )
+
+    -- Group label
+    group.Label = UIUtil.CreateText(group, groupLabel, 12, "Arial Bold")
     group.Label:SetColor("FFBEBEBE")
     group.Label:SetDropShadow(true)
 
-    # Energy Icon
+    -- Energy Icon
     group.EnergyIcon = Bitmap(group)
     group.EnergyIcon:SetTexture(UIUtil.UIFile('/game/unit-over/icon-energy_bmp.dds'))
 
-    # Energy Value
-    group.EnergyValue = UIUtil.CreateText( group, "0", 12, UIUtil.bodyFont )
+    -- Energy Value
+    group.EnergyValue = UIUtil.CreateText(group, "0", 12, UIUtil.bodyFont)
     group.EnergyValue:SetColor("FF00F000")
     group.EnergyValue:SetDropShadow(true)
 
-    # Mass Icon
+    -- Mass Icon
     group.MassIcon = Bitmap(group)
     group.MassIcon:SetTexture(UIUtil.UIFile('/game/unit-over/icon-mass_bmp.dds'))
 
-    # Mass Value
-    group.MassValue = UIUtil.CreateText( group, "0", 12, UIUtil.bodyFont )
+    -- Mass Value
+    group.MassValue = UIUtil.CreateText(group, "0", 12, UIUtil.bodyFont)
     group.MassValue:SetColor("FF00F000")
     group.MassValue:SetDropShadow(true)
 
@@ -43,11 +39,11 @@ end
 --       <icon> 24
 function CreateStatGroup(parent, labelIcon)
     local group = Group(parent)
-    
+
     group.Label = Bitmap(group)
     group.Label:SetTexture(labelIcon)
 
-    group.Value = UIUtil.CreateText( group, "", 14, UIUtil.bodyFont )
+    group.Value = UIUtil.CreateText(group, "", 14, UIUtil.bodyFont)
     group.Value:SetColor("FF00F000")
     group.Value:SetDropShadow(true)
 
@@ -56,7 +52,7 @@ end
 
 function CreateTextbox(parent, label, bigBG)
     local group = Group(parent)
-    
+
     if bigBG then
         group.TL = Bitmap(group)
         group.TM = Bitmap(group)
@@ -88,8 +84,8 @@ function CreateTextbox(parent, label, bigBG)
     end
 
     group.Value = {}
-    group.Value[1] = UIUtil.CreateText( group, "", 12, UIUtil.bodyFont)
-    
+    group.Value[1] = UIUtil.CreateText(group, "", 12, UIUtil.bodyFont)
+
     return group
 end
 
@@ -97,83 +93,82 @@ function Create(parent)
     if not import('/lua/ui/game/unitviewdetail.lua').View then
         import('/lua/ui/game/unitviewdetail.lua').View = Group(parent)
     end
-    
+
     local View = import('/lua/ui/game/unitviewdetail.lua').View
-    
+
     if not View.BG then
         View.BG = Bitmap(View)
     end
     View.BG:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/unit-over-back_bmp.dds'))
     View.BG.Depth:Set(200)
-    
+
     if not View.Bracket then
         View.Bracket = Bitmap(View)
     end
     View.Bracket:DisableHitTest()
     View.Bracket:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/bracket-unit_bmp.dds'))
-    
-    # Unit icon
+
+    -- Unit icon
     if false then
         View.UnitIcon = Bitmap(View)
     end
-    
+
     if not View.UnitImg then
-        View.UnitImg = Bitmap( View.BG )
+        View.UnitImg = Bitmap(View.BG)
     end
-    
-    # Unit Description
+
+    -- Unit Description
     if not View.UnitShortDesc then
-        View.UnitShortDesc = UIUtil.CreateText( View.BG, "", 10, UIUtil.bodyFont )
+        View.UnitShortDesc = UIUtil.CreateText(View.BG, "", 10, UIUtil.bodyFont)
     end
     View.UnitShortDesc:SetColor("FFFF9E06")
 
-    # Cost
+    -- Cost
     if not View.BuildCostGroup then
         View.BuildCostGroup = CreateResourceGroup(View.BG, "<LOC uvd_0000>Build Cost (Rate)")
     end
 
-    # Upkeep
+    -- Upkeep
     if not View.UpkeepGroup then
         View.UpkeepGroup = CreateResourceGroup(View.BG, "<LOC uvd_0002>Yield")
     end
-    
-    # Health stat
+
+    -- Health stat
     if not View.HealthStat then
-        View.HealthStat = CreateStatGroup( View.BG, UIUtil.UIFile('/game/unit_view_icons/redcross.dds') )
+        View.HealthStat = CreateStatGroup(View.BG, UIUtil.UIFile('/game/unit_view_icons/redcross.dds'))
     end
-    
+
     if not View.ShieldStat then
-        View.ShieldStat = CreateStatGroup( View.BG, UIUtil.UIFile('/game/unit_view_icons/shield.dds') )
+        View.ShieldStat = CreateStatGroup(View.BG, UIUtil.UIFile('/game/unit_view_icons/shield.dds'))
     end
-    
-    # Time stat
+    -- Tme stat
     if not View.TimeStat then
-        View.TimeStat = CreateStatGroup( View.BG, UIUtil.UIFile('/game/unit-over/icon-clock_bmp.dds') )
+        View.TimeStat = CreateStatGroup(View.BG, UIUtil.UIFile('/game/unit-over/icon-clock_bmp.dds'))
     end
-    
+
     if not View.TechLevel then
         View.TechLevel = UIUtil.CreateText(View.BG, '', 10, UIUtil.bodyFont)
     end
     View.TechLevel:SetColor("FFFF9E06")
-    
+
     if Prefs.GetOption('uvd_format') == 'full' then
-        # Description  "<LOC uvd_0003>Description"
+        -- Description  "<LOC uvd_0003>Description"
         if not View.Description then
             View.Description = CreateTextbox(View.BG, nil, true)
         end
     else
         if View.Description then View.Description:Destroy() View.Description = false end
     end
-    
+
     View.BG:DisableHitTest(true)
 end
 
 function SetLayout()
     local mapGroup = import('/lua/ui/game/unitviewdetail.lua').MapView
     import('/lua/ui/game/unitviewdetail.lua').ViewState = Prefs.GetOption('uvd_format')
-    
+
     Create(mapGroup)
-    
+
     local control = import('/lua/ui/game/unitviewdetail.lua').View
 
     local OrderGroup = false
@@ -183,22 +178,22 @@ function SetLayout()
 
     LayoutHelpers.AtBottomIn(control, control:GetParent(), 0)
     LayoutHelpers.AtLeftIn(control, control:GetParent(), 207)
-    control.Width:Set( control.BG.Width )
-    control.Height:Set( control.BG.Height )
-    
-    # Main window background
-    LayoutHelpers.AtLeftTopIn( control.BG, control )
-    
+    control.Width:Set(control.BG.Width)
+    control.Height:Set(control.BG.Height)
+
+    -- Main window background
+    LayoutHelpers.AtLeftTopIn(control.BG, control)
+
     LayoutHelpers.AtLeftTopIn(control.Bracket, control.BG, -6, 3)
     control.Bracket:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_t.dds'))
-    
+
     if not control.bracketMax then
         control.bracketMax = Bitmap(control.BG)
     end
     control.bracketMax:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_b.dds'))
     LayoutHelpers.AtLeftIn(control.bracketMax, control.BG, -6)
     LayoutHelpers.AtBottomIn(control.bracketMax, control.BG, 3)
-    
+
     if not control.bracketMid then
         control.bracketMid = Bitmap(control.BG)
     end
@@ -207,73 +202,70 @@ function SetLayout()
     control.bracketMid.Top:Set(control.Bracket.Bottom)
     control.bracketMid.Bottom:Set(control.bracketMax.Top)
 
-    # Unit Image
-    LayoutHelpers.AtLeftTopIn( control.UnitImg, control.BG, 12, 36 )
-    control.UnitImg.Height:Set(46)
-    control.UnitImg.Width:Set(48)
-    
-    # Tech Level Text
-    LayoutHelpers.CenteredBelow(control.TechLevel, control.UnitImg)
-    
-    # Unit Description
-    LayoutHelpers.AtLeftTopIn( control.UnitShortDesc, control.BG, 20, 13 )
-    control.UnitShortDesc:SetClipToWidth(true)
-    control.UnitShortDesc.Right:Set(function() return control.BG.Right() - 15 end)
+    -- Unit Image
+    LayoutHelpers.AtLeftTopIn(control.UnitImg, control.BG, 12, 36)
+    LayoutHelpers.SetDimensions(control.UnitImg, 48, 46)
 
-    # Time stat
-    LayoutHelpers.Below( control.TimeStat, control.UnitImg, 4 )
+    -- Tech Level Text
+    LayoutHelpers.CenteredBelow(control.TechLevel, control.UnitImg)
+
+    -- Unit Description
+    LayoutHelpers.AtLeftTopIn(control.UnitShortDesc, control.BG, 20, 13)
+    control.UnitShortDesc:SetClipToWidth(true)
+    LayoutHelpers.AtRightIn(control.UnitShortDesc, control.BG, 15)
+
+    -- Time stat
+    LayoutHelpers.Below(control.TimeStat, control.UnitImg, 4)
     LayoutHelpers.AtLeftIn(control.TimeStat, control.UnitImg, -2)
     control.TimeStat.Height:Set(control.TimeStat.Label.Height)
-    LayoutStatGroup( control.TimeStat )
-    
-    # Build Resource Group
-    LayoutHelpers.AtLeftTopIn( control.BuildCostGroup, control.BG, 70, 34 )
-    control.BuildCostGroup.Width:Set( 115 )
-    LayoutResourceGroup( control.BuildCostGroup )
-    control.BuildCostGroup.Bottom:Set( function() return control.BuildCostGroup.MassValue.Bottom() + 1 end )
+    LayoutStatGroup(control.TimeStat)
 
-    # Upkeep Resource Group
-    LayoutHelpers.RightOf( control.UpkeepGroup, control.BuildCostGroup )
-    control.UpkeepGroup.Width:Set( 55 )
-    control.UpkeepGroup.Bottom:Set( control.BuildCostGroup.Bottom )
-    LayoutResourceGroup( control.UpkeepGroup )
-    
-    # health stat
-    LayoutHelpers.RightOf( control.HealthStat, control.UpkeepGroup )
-    LayoutHelpers.AtTopIn( control.HealthStat, control.UpkeepGroup, 22 )
+    -- Build Resource Group
+    LayoutHelpers.AtLeftTopIn(control.BuildCostGroup, control.BG, 70, 34)
+    LayoutHelpers.SetWidth(control.BuildCostGroup, 115)
+    LayoutResourceGroup(control.BuildCostGroup)
+    LayoutHelpers.AtBottomIn(control.BuildCostGroup, control.BuildCostGroup.MassValue, -1)
+
+    -- Upkeep Resource Group
+    LayoutHelpers.RightOf(control.UpkeepGroup, control.BuildCostGroup)
+    LayoutHelpers.SetWidth(control.UpkeepGroup, 55)
+    control.UpkeepGroup.Bottom:Set(control.BuildCostGroup.Bottom)
+    LayoutResourceGroup(control.UpkeepGroup)
+
+    -- health stat
+    LayoutHelpers.RightOf(control.HealthStat, control.UpkeepGroup)
+    LayoutHelpers.AtTopIn(control.HealthStat, control.UpkeepGroup, 22)
     control.HealthStat.Height:Set(control.HealthStat.Label.Height)
-    LayoutStatGroup( control.HealthStat )
-    
-    # shield stat
-    LayoutHelpers.RightOf( control.ShieldStat, control.UpkeepGroup, -2 )
-    LayoutHelpers.AtTopIn( control.ShieldStat, control.UpkeepGroup, 42 )
+    LayoutStatGroup(control.HealthStat)
+
+    -- shield stat
+    LayoutHelpers.RightOf(control.ShieldStat, control.UpkeepGroup, -2)
+    LayoutHelpers.AtTopIn(control.ShieldStat, control.UpkeepGroup, 42)
     control.ShieldStat.Height:Set(control.ShieldStat.Label.Height)
-    LayoutStatGroup( control.ShieldStat )
-    
+    LayoutStatGroup(control.ShieldStat)
+
     if control.Description then
-        # Description
-        control.Description.Left:Set(function() return control.BG.Right() - 2 end)
-        control.Description.Bottom:Set(function() return control.BG.Bottom() - 2 end)
-        control.Description.Width:Set(400)
-        control.Description.Height:Set(20)
+        -- Description
+        LayoutHelpers.AnchorToRight(control.Description, control.BG, -2)
+        LayoutHelpers.AtBottomIn(control.Description, control.BG, 2)
+        LayoutHelpers.SetDimensions(control.Description, 400, 20)
         LayoutTextbox(control.Description)
     end
 end
 
 function LayoutResourceGroup(group)
-    
-    LayoutHelpers.AtTopIn( group.Label, group )
-    LayoutHelpers.AtLeftIn( group.Label, group )
+    LayoutHelpers.AtTopIn(group.Label, group)
+    LayoutHelpers.AtLeftIn(group.Label, group)
 
-    LayoutHelpers.Below( group.MassIcon, group.Label, 5 )
-    group.EnergyIcon.Left:Set( function() return group.Label.Left() - 4 end )
+    LayoutHelpers.Below(group.MassIcon, group.Label, 5)
+    LayoutHelpers.AtLeftIn(group.EnergyIcon, group.Label, -4)
 
-    LayoutHelpers.RightOf( group.EnergyValue, group.EnergyIcon, 1 )
-    group.EnergyValue.Top:Set( function() return group.EnergyIcon.Top() + 1 end )
+    LayoutHelpers.RightOf(group.EnergyValue, group.EnergyIcon, 1)
+    LayoutHelpers.AtTopIn(group.EnergyValue, group.EnergyIcon, 1)
 
-    LayoutHelpers.RightOf( group.MassValue, group.MassIcon, 1 )
-    group.MassValue.Right:Set( function() return group.Label.Right() end )
-    group.MassValue.Top:Set( function() return group.MassIcon.Top() + 1 end )
+    LayoutHelpers.RightOf(group.MassValue, group.MassIcon, 1)
+    group.MassValue.Right:Set(function() return group.Label.Right() end)
+    LayoutHelpers.AtTopIn(group.MassValue, group.MassIcon, 1)
 
     LayoutHelpers.Below(group.EnergyIcon, group.MassIcon, 5)
 end
@@ -282,44 +274,44 @@ function LayoutStatGroup(group)
     group.Width:Set(function() return group.Label.Width() + group.Value.Width() end)
     group.Label.Left:Set(group.Left)
     group.Label.Top:Set(group.Top)
-    group.Value.Left:Set(function() return group.Label.Right() + 4 end)
+    LayoutHelpers.AnchorToRight(group.Value, group.Label, 4)
     LayoutHelpers.AtVerticalCenterIn(group.Value, group.Label)
-end  
+end
 
 function LayoutTextbox(group)
     group.TL.Top:Set(group.Top)
     group.TL.Left:Set(group.Left)
-    
+
     group.TR.Top:Set(group.Top)
     group.TR.Right:Set(group.Right)
-    
+
     group.BL.Bottom:Set(group.Bottom)
     group.BL.Left:Set(group.Left)
-    
+
     group.BR.Bottom:Set(group.Bottom)
     group.BR.Right:Set(group.Right)
-    
-    group.TM.Top:Set(function() return group.Top() + 4 end)
+
+    LayoutHelpers.AtTopIn(group.TM, group, 4)
     group.TM.Left:Set(group.TL.Right)
     group.TM.Right:Set(group.TR.Left)
-    
-    group.BM.Bottom:Set(function() return group.Bottom() - 4 end)
+
+    LayoutHelpers.AtBottomIn(group.BM, group, 4)
     group.BM.Left:Set(group.BL.Right)
     group.BM.Right:Set(group.BR.Left)
-    
+
     group.ML.Left:Set(group.Left)
     group.ML.Top:Set(group.TL.Bottom)
     group.ML.Bottom:Set(group.BL.Top)
-    
+
     group.MR.Right:Set(group.Right)
     group.MR.Top:Set(group.TR.Bottom)
     group.MR.Bottom:Set(group.BR.Top)
-    
+
     group.M.Left:Set(group.ML.Right)
     group.M.Right:Set(group.MR.Left)
     group.M.Top:Set(group.TM.Bottom)
     group.M.Bottom:Set(group.BM.Top)
-    
+
     group.TL.Depth:Set(function() return group.Depth() - 1 end)
     group.TM.Depth:Set(group.TL.Depth)
     group.TR.Depth:Set(group.TL.Depth)
@@ -329,9 +321,9 @@ function LayoutTextbox(group)
     group.BL.Depth:Set(group.TL.Depth)
     group.BM.Depth:Set(group.TL.Depth)
     group.BR.Depth:Set(group.TL.Depth)
-    
+
     LayoutHelpers.AtLeftTopIn(group.Value[1], group, 24, 14)
-    group.Value[1].Right:Set(function() return group.Right() - 15 end)
-    group.Value[1].Width:Set(function() return group.Right() - group.Left() - 14 end)
+    LayoutHelpers.AtRightIn(group.Value[1], group, 15)
+    group.Value[1].Width:Set(function() return group.Right() - group.Left() - LayoutHelpers.ScaleNumber(14) end)
     group.Value[1]:SetClipToWidth(true)
 end

--- a/gamedata/lua/lua/ui/game/layouts/unitviewDetail_mini.lua
+++ b/gamedata/lua/lua/ui/game/layouts/unitviewDetail_mini.lua
@@ -1,36 +1,32 @@
-
 local UIUtil = import('/lua/ui/uiutil.lua')
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 local Group = import('/lua/maui/group.lua').Group
 local Bitmap = import('/lua/maui/bitmap.lua').Bitmap
-local GameCommon = import('/lua/ui/game/gamecommon.lua')
-local ItemList = import('/lua/maui/itemlist.lua').ItemList
 local Prefs = import('/lua/user/prefs.lua')
-
 
 function CreateResourceGroup(parent, groupLabel)
     local group = Group(parent)
-    
-    # Group label
-    group.Label = UIUtil.CreateText( group, groupLabel, 12, "Arial Bold" )
+
+    -- Group label
+    group.Label = UIUtil.CreateText(group, groupLabel, 12, "Arial Bold")
     group.Label:SetColor("FFBEBEBE")
     group.Label:SetDropShadow(true)
 
-    # Energy Icon
+    -- Energy Icon
     group.EnergyIcon = Bitmap(group)
     group.EnergyIcon:SetTexture(UIUtil.UIFile('/game/unit-over/icon-energy_bmp.dds'))
 
-    # Energy Value
-    group.EnergyValue = UIUtil.CreateText( group, "0", 12, UIUtil.bodyFont )
+    -- Energy Value
+    group.EnergyValue = UIUtil.CreateText(group, "0", 12, UIUtil.bodyFont)
     group.EnergyValue:SetColor("FF00F000")
     group.EnergyValue:SetDropShadow(true)
 
-    # Mass Icon
+    -- Mass Icon
     group.MassIcon = Bitmap(group)
     group.MassIcon:SetTexture(UIUtil.UIFile('/game/unit-over/icon-mass_bmp.dds'))
 
-    # Mass Value
-    group.MassValue = UIUtil.CreateText( group, "0", 12, UIUtil.bodyFont )
+    -- Mass Value
+    group.MassValue = UIUtil.CreateText(group, "0", 12, UIUtil.bodyFont)
     group.MassValue:SetColor("FF00F000")
     group.MassValue:SetDropShadow(true)
 
@@ -43,11 +39,11 @@ end
 --       <icon> 24
 function CreateStatGroup(parent, labelIcon)
     local group = Group(parent)
-    
+
     group.Label = Bitmap(group)
     group.Label:SetTexture(labelIcon)
 
-    group.Value = UIUtil.CreateText( group, "", 14, UIUtil.bodyFont )
+    group.Value = UIUtil.CreateText(group, "", 14, UIUtil.bodyFont)
     group.Value:SetColor("FF00F000")
     group.Value:SetDropShadow(true)
 
@@ -56,7 +52,7 @@ end
 
 function CreateTextbox(parent, label, bigBG)
     local group = Group(parent)
-    
+
     if bigBG then
         group.TL = Bitmap(group)
         group.TM = Bitmap(group)
@@ -88,8 +84,8 @@ function CreateTextbox(parent, label, bigBG)
     end
 
     group.Value = {}
-    group.Value[1] = UIUtil.CreateText( group, "", 12, UIUtil.bodyFont)
-    
+    group.Value[1] = UIUtil.CreateText(group, "", 12, UIUtil.bodyFont)
+
     return group
 end
 
@@ -97,82 +93,82 @@ function Create(parent)
     if not import('/lua/ui/game/unitviewdetail.lua').View then
         import('/lua/ui/game/unitviewdetail.lua').View = Group(parent)
     end
-    
+
     local View = import('/lua/ui/game/unitviewdetail.lua').View
-    
+
     if not View.BG then
         View.BG = Bitmap(View)
     end
     View.BG:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/unit-over-back_bmp.dds'))
     View.BG.Depth:Set(200)
-    
+
     if not View.Bracket then
         View.Bracket = Bitmap(View)
     end
     View.Bracket:DisableHitTest()
     View.Bracket:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/bracket-unit_bmp.dds'))
-    
-    # Unit icon
+
+    -- Unit icon
     if false then
         View.UnitIcon = Bitmap(View)
     end
-    
+
     if not View.UnitImg then
-        View.UnitImg = Bitmap( View.BG )
+        View.UnitImg = Bitmap(View.BG)
     end
-    
-    # Unit Description
+
+    -- Unit Description
     if not View.UnitShortDesc then
-        View.UnitShortDesc = UIUtil.CreateText( View.BG, "", 10, UIUtil.bodyFont )
+        View.UnitShortDesc = UIUtil.CreateText(View.BG, "", 10, UIUtil.bodyFont)
     end
     View.UnitShortDesc:SetColor("FFFF9E06")
 
-    # Cost
+    -- Cost
     if not View.BuildCostGroup then
         View.BuildCostGroup = CreateResourceGroup(View.BG, "<LOC uvd_0000>Build Cost (Rate)")
     end
 
-    # Upkeep
+    -- Upkeep
     if not View.UpkeepGroup then
         View.UpkeepGroup = CreateResourceGroup(View.BG, "<LOC uvd_0002>Yield")
     end
-    
-    # Health stat
+
+    -- Health stat
     if not View.HealthStat then
-        View.HealthStat = CreateStatGroup( View.BG, UIUtil.UIFile('/game/unit_view_icons/redcross.dds') )
+        View.HealthStat = CreateStatGroup(View.BG, UIUtil.UIFile('/game/unit_view_icons/redcross.dds'))
     end
-    
+
     if not View.ShieldStat then
-        View.ShieldStat = CreateStatGroup( View.BG, UIUtil.UIFile('/game/unit_view_icons/shield.dds') )
+        View.ShieldStat = CreateStatGroup(View.BG, UIUtil.UIFile('/game/unit_view_icons/shield.dds'))
     end
-    # Tme stat
+    -- Tme stat
     if not View.TimeStat then
-        View.TimeStat = CreateStatGroup( View.BG, UIUtil.UIFile('/game/unit-over/icon-clock_bmp.dds') )
+        View.TimeStat = CreateStatGroup(View.BG, UIUtil.UIFile('/game/unit-over/icon-clock_bmp.dds'))
     end
-    
+
     if not View.TechLevel then
         View.TechLevel = UIUtil.CreateText(View.BG, '', 10, UIUtil.bodyFont)
     end
     View.TechLevel:SetColor("FFFF9E06")
-    
+
     if Prefs.GetOption('uvd_format') == 'full' then
-        # Description  "<LOC uvd_0003>Description"
+        -- Description  "<LOC uvd_0003>Description"
         if not View.Description then
             View.Description = CreateTextbox(View.BG, nil, true)
         end
     else
         if View.Description then View.Description:Destroy() View.Description = false end
     end
-    
+
     View.BG:DisableHitTest(true)
 end
 
 function SetLayout()
     local mapGroup = import('/lua/ui/game/unitviewdetail.lua').MapView
     import('/lua/ui/game/unitviewdetail.lua').ViewState = Prefs.GetOption('uvd_format')
-    
+
     Create(mapGroup)
-    
+
     local control = import('/lua/ui/game/unitviewdetail.lua').View
 
     local OrderGroup = false
@@ -187,15 +183,15 @@ function SetLayout()
         LayoutHelpers.AtBottomIn(control, control:GetParent(), 140)
         LayoutHelpers.AtLeftIn(control, control:GetParent(), 0)
     end
-    control.Width:Set( control.BG.Width )
-    control.Height:Set( control.BG.Height )
-    
-    # Main window background
-    LayoutHelpers.AtLeftTopIn( control.BG, control )
-    
+    control.Width:Set(control.BG.Width)
+    control.Height:Set(control.BG.Height)
+
+    -- Main window background
+    LayoutHelpers.AtLeftTopIn(control.BG, control)
+
     LayoutHelpers.AtLeftTopIn(control.Bracket, control.BG, -18, -2)
     control.Bracket:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/bracket-unit_bmp.dds'))
-    
+
     if control.bracketMid then
         control.bracketMid:Destroy()
         control.bracketMid = false
@@ -204,72 +200,71 @@ function SetLayout()
         control.bracketMax:Destroy()
         control.bracketMax = false
     end
-    
-    # Unit Image
-    LayoutHelpers.AtLeftTopIn( control.UnitImg, control.BG, 12, 36 )
-	LayoutHelpers.SetDimensions(control.UnitImg, 48, 46)
-    
-    # Tech Level Text
-    LayoutHelpers.CenteredBelow(control.TechLevel, control.UnitImg)
-    
-    # Unit Description
-    LayoutHelpers.AtLeftTopIn( control.UnitShortDesc, control.BG, 20, 13 )
-    control.UnitShortDesc:SetClipToWidth(true)
-	LayoutHelpers.AtRightIn(control.UnitShortDesc, control.BG, 15)
 
-    # Time stat
-    LayoutHelpers.Below( control.TimeStat, control.UnitImg, 4 )
+    -- Unit Image
+    LayoutHelpers.AtLeftTopIn(control.UnitImg, control.BG, 12, 36)
+    LayoutHelpers.SetDimensions(control.UnitImg, 48, 46)
+
+    -- Tech Level Text
+    LayoutHelpers.CenteredBelow(control.TechLevel, control.UnitImg)
+
+    -- Unit Description
+    LayoutHelpers.AtLeftTopIn(control.UnitShortDesc, control.BG, 20, 13)
+    control.UnitShortDesc:SetClipToWidth(true)
+    LayoutHelpers.AtRightIn(control.UnitShortDesc, control.BG, 15)
+
+    -- Time stat
+    LayoutHelpers.Below(control.TimeStat, control.UnitImg, 4)
     LayoutHelpers.AtLeftIn(control.TimeStat, control.UnitImg, -2)
     control.TimeStat.Height:Set(control.TimeStat.Label.Height)
-    LayoutStatGroup( control.TimeStat )
-    
-    # Build Resource Group
-    LayoutHelpers.AtLeftTopIn( control.BuildCostGroup, control.BG, 70, 34 )
-	LayoutHelpers.SetWidth(control.BuildCostGroup, 115)
-    LayoutResourceGroup( control.BuildCostGroup )
-	LayoutHelpers.AtBottomIn(control.BuildCostGroup, control.BuildCostGroup.MassValue, -1)
+    LayoutStatGroup(control.TimeStat)
 
-    # Upkeep Resource Group
-    LayoutHelpers.RightOf( control.UpkeepGroup, control.BuildCostGroup )
-	LayoutHelpers.SetWidth(control.UpkeepGroup, 55)
-    control.UpkeepGroup.Bottom:Set( control.BuildCostGroup.Bottom )
-    LayoutResourceGroup( control.UpkeepGroup )
-    
-    # health stat
-    LayoutHelpers.RightOf( control.HealthStat, control.UpkeepGroup )
-    LayoutHelpers.AtTopIn( control.HealthStat, control.UpkeepGroup, 22 )
+    -- Build Resource Group
+    LayoutHelpers.AtLeftTopIn(control.BuildCostGroup, control.BG, 70, 34)
+    LayoutHelpers.SetWidth(control.BuildCostGroup, 115)
+    LayoutResourceGroup(control.BuildCostGroup)
+    LayoutHelpers.AtBottomIn(control.BuildCostGroup, control.BuildCostGroup.MassValue, -1)
+
+    -- Upkeep Resource Group
+    LayoutHelpers.RightOf(control.UpkeepGroup, control.BuildCostGroup)
+    LayoutHelpers.SetWidth(control.UpkeepGroup, 55)
+    control.UpkeepGroup.Bottom:Set(control.BuildCostGroup.Bottom)
+    LayoutResourceGroup(control.UpkeepGroup)
+
+    -- health stat
+    LayoutHelpers.RightOf(control.HealthStat, control.UpkeepGroup)
+    LayoutHelpers.AtTopIn(control.HealthStat, control.UpkeepGroup, 22)
     control.HealthStat.Height:Set(control.HealthStat.Label.Height)
-    LayoutStatGroup( control.HealthStat )
-    
-    # shield stat
-    LayoutHelpers.RightOf( control.ShieldStat, control.UpkeepGroup, -2 )
-    LayoutHelpers.AtTopIn( control.ShieldStat, control.UpkeepGroup, 42 )
+    LayoutStatGroup(control.HealthStat)
+
+    -- shield stat
+    LayoutHelpers.RightOf(control.ShieldStat, control.UpkeepGroup, -2)
+    LayoutHelpers.AtTopIn(control.ShieldStat, control.UpkeepGroup, 42)
     control.ShieldStat.Height:Set(control.ShieldStat.Label.Height)
-    LayoutStatGroup( control.ShieldStat )
-    
+    LayoutStatGroup(control.ShieldStat)
+
     if control.Description then
-        # Description
-		LayoutHelpers.AnchorToRight(control.Description, control.BG, -3)
-		LayoutHelpers.AtBottomIn(control.Description, control.BG, 20)
+        -- Description
+        LayoutHelpers.AnchorToRight(control.Description, control.BG, -3)
+        LayoutHelpers.AtBottomIn(control.Description, control.BG, 20)
         LayoutHelpers.SetDimensions(control.Description, 400, 20)
         LayoutTextbox(control.Description)
     end
 end
 
 function LayoutResourceGroup(group)
-    
-    LayoutHelpers.AtTopIn( group.Label, group )
-    LayoutHelpers.AtLeftIn( group.Label, group )
+    LayoutHelpers.AtTopIn(group.Label, group)
+    LayoutHelpers.AtLeftIn(group.Label, group)
 
-    LayoutHelpers.Below( group.MassIcon, group.Label, 5 )
-    LayoutHelpers.AtLeftIn( group.EnergyIcon, group.Label, -4 )
+    LayoutHelpers.Below(group.MassIcon, group.Label, 5)
+    LayoutHelpers.AtLeftIn(group.EnergyIcon, group.Label, -4)
 
-    LayoutHelpers.RightOf( group.EnergyValue, group.EnergyIcon, 1 )
-	LayoutHelpers.AtTopIn( group.EnergyValue, group.EnergyIcon, 1 )
+    LayoutHelpers.RightOf(group.EnergyValue, group.EnergyIcon, 1)
+    LayoutHelpers.AtTopIn(group.EnergyValue, group.EnergyIcon, 1)
 
-    LayoutHelpers.RightOf( group.MassValue, group.MassIcon, 1 )
-	LayoutHelpers.AtRightIn( group.MassValue, group.Label )
-	LayoutHelpers.AtTopIn( group.MassValue, group.MassIcon, 1 )
+    LayoutHelpers.RightOf(group.MassValue, group.MassIcon, 1)
+    group.MassValue.Right:Set(group.Label.Right)
+    LayoutHelpers.AtTopIn(group.MassValue, group.MassIcon, 1)
 
     LayoutHelpers.Below(group.EnergyIcon, group.MassIcon, 5)
 end
@@ -278,44 +273,44 @@ function LayoutStatGroup(group)
     group.Width:Set(function() return group.Label.Width() + group.Value.Width() end)
     group.Label.Left:Set(group.Left)
     group.Label.Top:Set(group.Top)
-	LayoutHelpers.AnchorToRight(group.Value, group.Label, 4)
+    LayoutHelpers.AnchorToRight(group.Value, group.Label, 4)
     LayoutHelpers.AtVerticalCenterIn(group.Value, group.Label)
-end  
+end
 
 function LayoutTextbox(group)
     group.TL.Top:Set(group.Top)
     group.TL.Left:Set(group.Left)
-    
+
     group.TR.Top:Set(group.Top)
     group.TR.Right:Set(group.Right)
-    
+
     group.BL.Bottom:Set(group.Bottom)
     group.BL.Left:Set(group.Left)
-    
+
     group.BR.Bottom:Set(group.Bottom)
     group.BR.Right:Set(group.Right)
-    
-	LayoutHelpers.AtTopIn(group.TM, group, 4)
+
+    LayoutHelpers.AtTopIn(group.TM, group, 4)
     group.TM.Left:Set(group.TL.Right)
     group.TM.Right:Set(group.TR.Left)
-    
+
     LayoutHelpers.AtBottomIn(group.BM, group, 4)
     group.BM.Left:Set(group.BL.Right)
     group.BM.Right:Set(group.BR.Left)
-    
+
     group.ML.Left:Set(group.Left)
     group.ML.Top:Set(group.TL.Bottom)
     group.ML.Bottom:Set(group.BL.Top)
-    
+
     group.MR.Right:Set(group.Right)
     group.MR.Top:Set(group.TR.Bottom)
     group.MR.Bottom:Set(group.BR.Top)
-    
+
     group.M.Left:Set(group.ML.Right)
     group.M.Right:Set(group.MR.Left)
     group.M.Top:Set(group.TM.Bottom)
     group.M.Bottom:Set(group.BM.Top)
-    
+
     group.TL.Depth:Set(function() return group.Depth() - 1 end)
     group.TM.Depth:Set(group.TL.Depth)
     group.TR.Depth:Set(group.TL.Depth)
@@ -325,9 +320,9 @@ function LayoutTextbox(group)
     group.BL.Depth:Set(group.TL.Depth)
     group.BM.Depth:Set(group.TL.Depth)
     group.BR.Depth:Set(group.TL.Depth)
-    
+
     LayoutHelpers.AtLeftTopIn(group.Value[1], group, 24, 14)
-	LayoutHelpers.AtRightIn(group.Value[1], group, 15)
+    LayoutHelpers.AtRightIn(group.Value[1], group, 15)
     group.Value[1].Width:Set(function() return group.Right() - group.Left() - LayoutHelpers.ScaleNumber(14) end)
     group.Value[1]:SetClipToWidth(true)
 end

--- a/gamedata/lua/lua/ui/game/layouts/unitviewDetail_right.lua
+++ b/gamedata/lua/lua/ui/game/layouts/unitviewDetail_right.lua
@@ -1,36 +1,32 @@
-
 local UIUtil = import('/lua/ui/uiutil.lua')
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 local Group = import('/lua/maui/group.lua').Group
 local Bitmap = import('/lua/maui/bitmap.lua').Bitmap
-local GameCommon = import('/lua/ui/game/gamecommon.lua')
-local ItemList = import('/lua/maui/itemlist.lua').ItemList
 local Prefs = import('/lua/user/prefs.lua')
-
 
 function CreateResourceGroup(parent, groupLabel)
     local group = Group(parent)
-    
-    # Group label
-    group.Label = UIUtil.CreateText( group, groupLabel, 12, "Arial Bold" )
+
+    -- Group label
+    group.Label = UIUtil.CreateText(group, groupLabel, 12, "Arial Bold")
     group.Label:SetColor("FFBEBEBE")
     group.Label:SetDropShadow(true)
 
-    # Energy Icon
+    -- Energy Icon
     group.EnergyIcon = Bitmap(group)
     group.EnergyIcon:SetTexture(UIUtil.UIFile('/game/unit-over/icon-energy_bmp.dds'))
 
-    # Energy Value
-    group.EnergyValue = UIUtil.CreateText( group, "0", 12, UIUtil.bodyFont )
+    -- Energy Value
+    group.EnergyValue = UIUtil.CreateText(group, "0", 12, UIUtil.bodyFont)
     group.EnergyValue:SetColor("FF00F000")
     group.EnergyValue:SetDropShadow(true)
 
-    # Mass Icon
+    -- Mass Icon
     group.MassIcon = Bitmap(group)
     group.MassIcon:SetTexture(UIUtil.UIFile('/game/unit-over/icon-mass_bmp.dds'))
 
-    # Mass Value
-    group.MassValue = UIUtil.CreateText( group, "0", 12, UIUtil.bodyFont )
+    -- Mass Value
+    group.MassValue = UIUtil.CreateText(group, "0", 12, UIUtil.bodyFont)
     group.MassValue:SetColor("FF00F000")
     group.MassValue:SetDropShadow(true)
 
@@ -43,11 +39,11 @@ end
 --       <icon> 24
 function CreateStatGroup(parent, labelIcon)
     local group = Group(parent)
-    
+
     group.Label = Bitmap(group)
     group.Label:SetTexture(labelIcon)
 
-    group.Value = UIUtil.CreateText( group, "", 14, UIUtil.bodyFont )
+    group.Value = UIUtil.CreateText(group, "", 14, UIUtil.bodyFont)
     group.Value:SetColor("FF00F000")
     group.Value:SetDropShadow(true)
 
@@ -56,7 +52,7 @@ end
 
 function CreateTextbox(parent, label, bigBG)
     local group = Group(parent)
-    
+
     if bigBG then
         group.TL = Bitmap(group)
         group.TM = Bitmap(group)
@@ -88,8 +84,8 @@ function CreateTextbox(parent, label, bigBG)
     end
 
     group.Value = {}
-    group.Value[1] = UIUtil.CreateText( group, "", 12, UIUtil.bodyFont)
-    
+    group.Value[1] = UIUtil.CreateText(group, "", 12, UIUtil.bodyFont)
+
     return group
 end
 
@@ -97,82 +93,82 @@ function Create(parent)
     if not import('/lua/ui/game/unitviewdetail.lua').View then
         import('/lua/ui/game/unitviewdetail.lua').View = Group(parent)
     end
-    
+
     local View = import('/lua/ui/game/unitviewdetail.lua').View
-    
+
     if not View.BG then
         View.BG = Bitmap(View)
     end
     View.BG:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/unit-over-back_bmp.dds'))
     View.BG.Depth:Set(200)
-    
+
     if not View.Bracket then
         View.Bracket = Bitmap(View)
     end
     View.Bracket:DisableHitTest()
     View.Bracket:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/bracket-unit_bmp.dds'))
-    
-    # Unit icon
+
+    -- Unit icon
     if false then
         View.UnitIcon = Bitmap(View)
     end
-    
+
     if not View.UnitImg then
-        View.UnitImg = Bitmap( View.BG )
+        View.UnitImg = Bitmap(View.BG)
     end
-    
-    # Unit Description
+
+    -- Unit Description
     if not View.UnitShortDesc then
-        View.UnitShortDesc = UIUtil.CreateText( View.BG, "", 10, UIUtil.bodyFont )
+        View.UnitShortDesc = UIUtil.CreateText(View.BG, "", 10, UIUtil.bodyFont)
     end
     View.UnitShortDesc:SetColor("FFFF9E06")
 
-    # Cost
+    -- Cost
     if not View.BuildCostGroup then
         View.BuildCostGroup = CreateResourceGroup(View.BG, "<LOC uvd_0000>Build Cost (Rate)")
     end
 
-    # Upkeep
+    -- Upkeep
     if not View.UpkeepGroup then
         View.UpkeepGroup = CreateResourceGroup(View.BG, "<LOC uvd_0002>Yield")
     end
-    
-    # Health stat
+
+    -- Health stat
     if not View.HealthStat then
-        View.HealthStat = CreateStatGroup( View.BG, UIUtil.UIFile('/game/unit_view_icons/redcross.dds') )
+        View.HealthStat = CreateStatGroup(View.BG, UIUtil.UIFile('/game/unit_view_icons/redcross.dds'))
     end
-    
+
     if not View.ShieldStat then
-        View.ShieldStat = CreateStatGroup( View.BG, UIUtil.UIFile('/game/unit_view_icons/shield.dds') )
+        View.ShieldStat = CreateStatGroup(View.BG, UIUtil.UIFile('/game/unit_view_icons/shield.dds'))
     end
-    # Tme stat
+    -- Tme stat
     if not View.TimeStat then
-        View.TimeStat = CreateStatGroup( View.BG, UIUtil.UIFile('/game/unit-over/icon-clock_bmp.dds') )
+        View.TimeStat = CreateStatGroup(View.BG, UIUtil.UIFile('/game/unit-over/icon-clock_bmp.dds'))
     end
-    
+
     if not View.TechLevel then
         View.TechLevel = UIUtil.CreateText(View.BG, '', 10, UIUtil.bodyFont)
     end
     View.TechLevel:SetColor("FFFF9E06")
-    
+
     if Prefs.GetOption('uvd_format') == 'full' then
-        # Description  "<LOC uvd_0003>Description"
+        -- Description  "<LOC uvd_0003>Description"
         if not View.Description then
             View.Description = CreateTextbox(View.BG, nil, true)
         end
     else
         if View.Description then View.Description:Destroy() View.Description = false end
     end
-    
+
     View.BG:DisableHitTest(true)
 end
 
 function SetLayout()
     local mapGroup = import('/lua/ui/game/unitviewdetail.lua').MapView
     import('/lua/ui/game/unitviewdetail.lua').ViewState = Prefs.GetOption('uvd_format')
-    
+
     Create(mapGroup)
-    
+
     local control = import('/lua/ui/game/unitviewdetail.lua').View
 
     local OrderGroup = false
@@ -187,15 +183,15 @@ function SetLayout()
         LayoutHelpers.AtBottomIn(control, control:GetParent(), 140)
         LayoutHelpers.AtLeftIn(control, control:GetParent(), 18)
     end
-    control.Width:Set( control.BG.Width )
-    control.Height:Set( control.BG.Height )
-    
-    # Main window background
-    LayoutHelpers.AtLeftTopIn( control.BG, control )
-    
+    control.Width:Set(control.BG.Width)
+    control.Height:Set(control.BG.Height)
+
+    -- Main window background
+    LayoutHelpers.AtLeftTopIn(control.BG, control)
+
     LayoutHelpers.AtLeftTopIn(control.Bracket, control.BG, -19, -2)
     control.Bracket:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/bracket-unit_bmp.dds'))
-    
+
     if control.bracketMid then
         control.bracketMid:Destroy()
         control.bracketMid = false
@@ -204,74 +200,71 @@ function SetLayout()
         control.bracketMax:Destroy()
         control.bracketMax = false
     end
-    
-    # Unit Image
-    LayoutHelpers.AtLeftTopIn( control.UnitImg, control.BG, 12, 36 )
-    control.UnitImg.Height:Set(46)
-    control.UnitImg.Width:Set(48)
-    
-    # Tech Level Text
-    LayoutHelpers.CenteredBelow(control.TechLevel, control.UnitImg)
-    
-    # Unit Description
-    LayoutHelpers.AtLeftTopIn( control.UnitShortDesc, control.BG, 20, 13 )
-    control.UnitShortDesc:SetClipToWidth(true)
-    control.UnitShortDesc.Right:Set(function() return control.BG.Right() - 15 end)
 
-    # Time stat
-    LayoutHelpers.Below( control.TimeStat, control.UnitImg, 4 )
+    -- Unit Image
+    LayoutHelpers.AtLeftTopIn(control.UnitImg, control.BG, 12, 36)
+    LayoutHelpers.SetDimensions(control.UnitImg, 48, 46)
+
+    -- Tech Level Text
+    LayoutHelpers.CenteredBelow(control.TechLevel, control.UnitImg)
+
+    -- Unit Description
+    LayoutHelpers.AtLeftTopIn(control.UnitShortDesc, control.BG, 20, 13)
+    control.UnitShortDesc:SetClipToWidth(true)
+    LayoutHelpers.AtRightIn(control.UnitShortDesc, control.BG, 15)
+
+    -- Time stat
+    LayoutHelpers.Below(control.TimeStat, control.UnitImg, 4)
     LayoutHelpers.AtLeftIn(control.TimeStat, control.UnitImg, -2)
     control.TimeStat.Height:Set(control.TimeStat.Label.Height)
-    LayoutStatGroup( control.TimeStat )
-    
-    # Build Resource Group
-    LayoutHelpers.AtLeftTopIn( control.BuildCostGroup, control.BG, 70, 34 )
-    control.BuildCostGroup.Width:Set( 115 )
-    LayoutResourceGroup( control.BuildCostGroup )
-    control.BuildCostGroup.Bottom:Set( function() return control.BuildCostGroup.MassValue.Bottom() + 1 end )
+    LayoutStatGroup(control.TimeStat)
 
-    # Upkeep Resource Group
-    LayoutHelpers.RightOf( control.UpkeepGroup, control.BuildCostGroup )
-    control.UpkeepGroup.Width:Set( 55 )
-    control.UpkeepGroup.Bottom:Set( control.BuildCostGroup.Bottom )
-    LayoutResourceGroup( control.UpkeepGroup )
-    
-    # health stat
-    LayoutHelpers.RightOf( control.HealthStat, control.UpkeepGroup )
-    LayoutHelpers.AtTopIn( control.HealthStat, control.UpkeepGroup, 22 )
+    -- Build Resource Group
+    LayoutHelpers.AtLeftTopIn(control.BuildCostGroup, control.BG, 70, 34)
+    LayoutHelpers.SetWidth(control.BuildCostGroup, 115)
+    LayoutResourceGroup(control.BuildCostGroup)
+    LayoutHelpers.AtBottomIn(control.BuildCostGroup, control.BuildCostGroup.MassValue, -1)
+
+    -- Upkeep Resource Group
+    LayoutHelpers.RightOf(control.UpkeepGroup, control.BuildCostGroup)
+    LayoutHelpers.SetWidth(control.UpkeepGroup, 55)
+    control.UpkeepGroup.Bottom:Set(control.BuildCostGroup.Bottom)
+    LayoutResourceGroup(control.UpkeepGroup)
+
+    -- health stat
+    LayoutHelpers.RightOf(control.HealthStat, control.UpkeepGroup)
+    LayoutHelpers.AtTopIn(control.HealthStat, control.UpkeepGroup, 22)
     control.HealthStat.Height:Set(control.HealthStat.Label.Height)
-    LayoutStatGroup( control.HealthStat )
-    
-    # shield stat
-    LayoutHelpers.RightOf( control.ShieldStat, control.UpkeepGroup, -2 )
-    LayoutHelpers.AtTopIn( control.ShieldStat, control.UpkeepGroup, 42 )
+    LayoutStatGroup(control.HealthStat)
+
+    -- shield stat
+    LayoutHelpers.RightOf(control.ShieldStat, control.UpkeepGroup, -2)
+    LayoutHelpers.AtTopIn(control.ShieldStat, control.UpkeepGroup, 42)
     control.ShieldStat.Height:Set(control.ShieldStat.Label.Height)
-    LayoutStatGroup( control.ShieldStat )
-    
+    LayoutStatGroup(control.ShieldStat)
+
     if control.Description then
-        # Description
-        control.Description.Left:Set(function() return control.BG.Right() - 2 end)
-        control.Description.Bottom:Set(function() return control.BG.Bottom() - 2 end)
-        control.Description.Width:Set(400)
-        control.Description.Height:Set(20)
+        -- Description
+        LayoutHelpers.AnchorToRight(control.Description, control.BG, -2)
+        LayoutHelpers.AtBottomIn(control.Description, control.BG, 2)
+        LayoutHelpers.SetDimensions(control.Description, 400, 20)
         LayoutTextbox(control.Description)
     end
 end
 
 function LayoutResourceGroup(group)
-    
-    LayoutHelpers.AtTopIn( group.Label, group )
-    LayoutHelpers.AtLeftIn( group.Label, group )
+    LayoutHelpers.AtTopIn(group.Label, group)
+    LayoutHelpers.AtLeftIn(group.Label, group)
 
-    LayoutHelpers.Below( group.MassIcon, group.Label, 5 )
-    group.EnergyIcon.Left:Set( function() return group.Label.Left() - 4 end )
+    LayoutHelpers.Below(group.MassIcon, group.Label, 5)
+    LayoutHelpers.AtLeftIn(group.EnergyIcon, group.Label, -4)
 
-    LayoutHelpers.RightOf( group.EnergyValue, group.EnergyIcon, 1 )
-    group.EnergyValue.Top:Set( function() return group.EnergyIcon.Top() + 1 end )
+    LayoutHelpers.RightOf(group.EnergyValue, group.EnergyIcon, 1)
+    LayoutHelpers.AtTopIn(group.EnergyValue, group.EnergyIcon, 1)
 
-    LayoutHelpers.RightOf( group.MassValue, group.MassIcon, 1 )
-    group.MassValue.Right:Set( function() return group.Label.Right() end )
-    group.MassValue.Top:Set( function() return group.MassIcon.Top() + 1 end )
+    LayoutHelpers.RightOf(group.MassValue, group.MassIcon, 1)
+    group.MassValue.Right:Set(function() return group.Label.Right() end)
+    LayoutHelpers.AtTopIn(group.MassValue, group.MassIcon, 1)
 
     LayoutHelpers.Below(group.EnergyIcon, group.MassIcon, 5)
 end
@@ -280,44 +273,44 @@ function LayoutStatGroup(group)
     group.Width:Set(function() return group.Label.Width() + group.Value.Width() end)
     group.Label.Left:Set(group.Left)
     group.Label.Top:Set(group.Top)
-    group.Value.Left:Set(function() return group.Label.Right() + 4 end)
+    LayoutHelpers.AnchorToRight(group.Value, group.Label, 4)
     LayoutHelpers.AtVerticalCenterIn(group.Value, group.Label)
-end  
+end
 
 function LayoutTextbox(group)
     group.TL.Top:Set(group.Top)
     group.TL.Left:Set(group.Left)
-    
+
     group.TR.Top:Set(group.Top)
     group.TR.Right:Set(group.Right)
-    
+
     group.BL.Bottom:Set(group.Bottom)
     group.BL.Left:Set(group.Left)
-    
+
     group.BR.Bottom:Set(group.Bottom)
     group.BR.Right:Set(group.Right)
-    
-    group.TM.Top:Set(function() return group.Top() + 4 end)
+
+    LayoutHelpers.AtTopIn(group.TM, group, 4)
     group.TM.Left:Set(group.TL.Right)
     group.TM.Right:Set(group.TR.Left)
-    
-    group.BM.Bottom:Set(function() return group.Bottom() - 4 end)
+
+    LayoutHelpers.AtBottomIn(group.BM, group, 4)
     group.BM.Left:Set(group.BL.Right)
     group.BM.Right:Set(group.BR.Left)
-    
+
     group.ML.Left:Set(group.Left)
     group.ML.Top:Set(group.TL.Bottom)
     group.ML.Bottom:Set(group.BL.Top)
-    
+
     group.MR.Right:Set(group.Right)
     group.MR.Top:Set(group.TR.Bottom)
     group.MR.Bottom:Set(group.BR.Top)
-    
+
     group.M.Left:Set(group.ML.Right)
     group.M.Right:Set(group.MR.Left)
     group.M.Top:Set(group.TM.Bottom)
     group.M.Bottom:Set(group.BM.Top)
-    
+
     group.TL.Depth:Set(function() return group.Depth() - 1 end)
     group.TM.Depth:Set(group.TL.Depth)
     group.TR.Depth:Set(group.TL.Depth)
@@ -327,9 +320,9 @@ function LayoutTextbox(group)
     group.BL.Depth:Set(group.TL.Depth)
     group.BM.Depth:Set(group.TL.Depth)
     group.BR.Depth:Set(group.TL.Depth)
-    
+
     LayoutHelpers.AtLeftTopIn(group.Value[1], group, 24, 14)
-    group.Value[1].Right:Set(function() return group.Right() - 15 end)
-    group.Value[1].Width:Set(function() return group.Right() - group.Left() - 14 end)
+    LayoutHelpers.AtRightIn(group.Value[1], group, 15)
+    group.Value[1].Width:Set(function() return group.Right() - group.Left() - LayoutHelpers.ScaleNumber(14) end)
     group.Value[1]:SetClipToWidth(true)
 end

--- a/gamedata/lua/lua/ui/game/layouts/unitview_left.lua
+++ b/gamedata/lua/lua/ui/game/layouts/unitview_left.lua
@@ -1,24 +1,46 @@
-
 local UIUtil = import('/lua/ui/uiutil.lua')
 local Bitmap = import('/lua/maui/bitmap.lua').Bitmap
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
+local options = import('/lua/user/prefs.lua').GetFromCurrentProfile('options')
+local controls = import('/lua/ui/game/unitview.lua').controls
+local consControl = import('/lua/ui/game/construction.lua').controls.constructionGroup
+
+local iconPositions = {
+    [1] = {Left = 70, Top = 55},
+    [2] = {Left = 70, Top = 70},
+    [3] = {Left = 190, Top = 60},
+    [4] = {Left = 130, Top = 55},
+    [5] = {Left = 130, Top = 85},
+    [6] = {Left = 130, Top = 70},
+    [7] = {Left = 190, Top = 85},
+    [8] = {Left = 70, Top = 85},
+}
+local iconTextures = {
+    UIUtil.UIFile('/game/unit_view_icons/mass.dds'),
+    UIUtil.UIFile('/game/unit_view_icons/energy.dds'),
+    UIUtil.UIFile('/game/unit_view_icons/kills.dds'),
+    UIUtil.UIFile('/game/unit_view_icons/kills.dds'),
+    UIUtil.UIFile('/game/unit_view_icons/missiles.dds'),
+    UIUtil.UIFile('/game/unit_view_icons/shield.dds'),
+    UIUtil.UIFile('/game/unit_view_icons/fuel.dds'),
+    UIUtil.UIFile('/game/unit_view_icons/build.dds'),
+}
 
 function SetLayout()
-    local controls = import('/lua/ui/game/unitview.lua').controls
     controls.bg:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/build-over-back_bmp.dds'))
     LayoutHelpers.AtLeftIn(controls.bg, controls.parent)
     LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
-    
+
     controls.bracket:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_t.dds'))
     LayoutHelpers.AtLeftTopIn(controls.bracket, controls.bg, -6, 3)
-    
+
     if not controls.bracketMax then
         controls.bracketMax = Bitmap(controls.bg)
     end
     controls.bracketMax:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_b.dds'))
     LayoutHelpers.AtLeftIn(controls.bracketMax, controls.bg, -6)
     LayoutHelpers.AtBottomIn(controls.bracketMax, controls.bg, 3)
-    
+
     if not controls.bracketMid then
         controls.bracketMid = Bitmap(controls.bg)
     end
@@ -26,15 +48,14 @@ function SetLayout()
     LayoutHelpers.AtLeftIn(controls.bracketMid, controls.bg, -6)
     controls.bracketMid.Top:Set(controls.bracket.Bottom)
     controls.bracketMid.Bottom:Set(controls.bracketMax.Top)
-    
+
     LayoutHelpers.AtLeftTopIn(controls.name, controls.bg, 16, 14)
     LayoutHelpers.AtRightIn(controls.name, controls.bg, 16)
     controls.name:SetClipToWidth(true)
     controls.name:SetDropShadow(true)
-    
+
     LayoutHelpers.AtLeftTopIn(controls.icon, controls.bg, 12, 34)
-    controls.icon.Height:Set(48)
-    controls.icon.Width:Set(48)
+    LayoutHelpers.SetDimensions(controls.icon, 48, 48)
     LayoutHelpers.AtLeftTopIn(controls.stratIcon, controls.icon)
     LayoutHelpers.Below(controls.vetIcons[1], controls.icon, 5)
     LayoutHelpers.AtLeftIn(controls.vetIcons[1], controls.icon, -5)
@@ -43,38 +64,33 @@ function SetLayout()
         LayoutHelpers.RightOf(controls.vetIcons[i], controls.vetIcons[i-1], -3)
     end
     LayoutHelpers.AtLeftTopIn(controls.healthBar, controls.bg, 66, 35)
-    controls.healthBar.Width:Set(188)
-    controls.healthBar.Height:Set(16)
+    LayoutHelpers.SetDimensions(controls.healthBar, 188, 16)
     controls.healthBar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_bg.dds'))
     controls.healthBar._bar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_green.dds'))
     LayoutHelpers.AtBottomIn(controls.shieldBar, controls.healthBar)
     LayoutHelpers.AtLeftIn(controls.shieldBar, controls.healthBar)
-    controls.shieldBar.Width:Set(188)
-    controls.shieldBar.Height:Set(2)
+    LayoutHelpers.SetDimensions(controls.shieldBar, 188, 2)
     controls.shieldBar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_bg.dds'))
     controls.shieldBar._bar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/shieldbar.dds'))
     LayoutHelpers.Below(controls.fuelBar, controls.shieldBar)
-    controls.fuelBar.Width:Set(188)
-    controls.fuelBar.Height:Set(2)
+    LayoutHelpers.SetDimensions(controls.fuelBar, 188, 2)
     controls.fuelBar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_bg.dds'))
     controls.fuelBar._bar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/fuelbar.dds'))
+
+    LayoutHelpers.AtLeftTopIn(controls.vetBar, controls.bg, 192, 68)
+    LayoutHelpers.SetDimensions(controls.vetBar, 56, 3)
+    controls.vetBar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_bg.dds'))
+    controls.vetBar._bar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/fuelbar.dds'))
+    
+    LayoutHelpers.Below(controls.nextVet, controls.vetBar)
+    controls.nextVet:SetDropShadow(true)
+    LayoutHelpers.Above(controls.vetTitle, controls.vetBar)
+    controls.vetTitle:SetDropShadow(true)
+
     LayoutHelpers.AtCenterIn(controls.health, controls.healthBar)
     controls.health:SetDropShadow(true)
-    
-    local iconPositions = {
-        [1] = {Left = 70, Top = 60},
-        [3] = {Left = 140, Top = 60},
-        [5] = {Left = 190, Top = 60},
-    }
-    local iconTextures = {
-        UIUtil.UIFile('/game/unit_view_icons/mass.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/energy.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/kills.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/missiles.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/shield.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/fuel.dds'),
-    }
-    for index = 1, 6 do
+
+    for index = 1, table.getn(iconPositions) do
         local i = index
         if iconPositions[i] then
             LayoutHelpers.AtLeftTopIn(controls.statGroups[i].icon, controls.bg, iconPositions[i].Left, iconPositions[i].Top)
@@ -87,78 +103,73 @@ function SetLayout()
         controls.statGroups[i].value:SetDropShadow(true)
     end
     LayoutHelpers.AtLeftTopIn(controls.actionIcon, controls.bg, 261, 34)
-    controls.actionIcon.Height:Set(48)
-    controls.actionIcon.Width:Set(48)
+    LayoutHelpers.SetDimensions(controls.actionIcon, 48, 48)
     LayoutHelpers.Below(controls.actionText, controls.actionIcon)
     LayoutHelpers.AtHorizontalCenterIn(controls.actionText, controls.actionIcon)
-    
-    controls.abilities.Left:Set(function() return controls.bg.Right() + 20 end)
-    controls.abilities.Bottom:Set(function() return controls.bg.Bottom() - 24 end)
-    controls.abilities.Height:Set(50)
-    controls.abilities.Width:Set(200)
-    
+
+    LayoutHelpers.AnchorToRight(controls.abilities, controls.bg, 20)
+    LayoutHelpers.AtBottomIn(controls.abilities, controls.bg, 24)
+    LayoutHelpers.SetDimensions(controls.abilities, 200, 50)
+
+    SetBG(controls)
+
+    if options.gui_detailed_unitview ~= 0 then
+        LayoutHelpers.AtLeftTopIn(controls.healthBar, controls.bg, 66, 25)
+        LayoutHelpers.Below(controls.shieldBar, controls.healthBar)
+        LayoutHelpers.SetHeight(controls.shieldBar, 14)
+        LayoutHelpers.CenteredBelow(controls.shieldText, controls.shieldBar,0)
+        LayoutHelpers.SetHeight(controls.shieldBar, 2)
+    else
+        LayoutHelpers.AtLeftTopIn(controls.statGroups[1].icon, controls.bg, 70, 60)
+        LayoutHelpers.AtLeftTopIn(controls.statGroups[2].icon, controls.bg, 70, 80)
+    end
+end
+
+function SetBG(controls)
     controls.abilityBG.TL:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_ul.dds'))
     controls.abilityBG.TL.Right:Set(controls.abilities.Left)
     controls.abilityBG.TL.Bottom:Set(controls.abilities.Top)
-    
+
     controls.abilityBG.TM:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_horz_um.dds'))
     controls.abilityBG.TM.Right:Set(controls.abilityBG.TL.Right)
-    controls.abilityBG.TM.Bottom:Set(function() return controls.abilities.Top() end)
+    controls.abilityBG.TM.Bottom:Set(controls.abilities.Top)
     controls.abilityBG.TM.Left:Set(controls.abilityBG.TR.Left)
-    
+
     controls.abilityBG.TR:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_ur.dds'))
     controls.abilityBG.TR.Left:Set(controls.abilities.Right)
     controls.abilityBG.TR.Bottom:Set(controls.abilities.Top)
-    
+
     controls.abilityBG.ML:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_vert_l.dds'))
     controls.abilityBG.ML.Right:Set(controls.abilities.Left)
     controls.abilityBG.ML.Top:Set(controls.abilityBG.TL.Bottom)
     controls.abilityBG.ML.Bottom:Set(controls.abilityBG.BL.Top)
-    
+
     controls.abilityBG.M:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_m.dds'))
     controls.abilityBG.M.Top:Set(controls.abilityBG.TM.Bottom)
     controls.abilityBG.M.Left:Set(controls.abilityBG.ML.Right)
     controls.abilityBG.M.Right:Set(controls.abilityBG.MR.Left)
     controls.abilityBG.M.Bottom:Set(controls.abilityBG.BM.Top)
-    
+
     controls.abilityBG.MR:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_vert_r.dds'))
     controls.abilityBG.MR.Left:Set(controls.abilities.Right)
     controls.abilityBG.MR.Top:Set(controls.abilityBG.TR.Bottom)
     controls.abilityBG.MR.Bottom:Set(controls.abilityBG.BR.Top)
-    
+
     controls.abilityBG.BL:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_ll.dds'))
     controls.abilityBG.BL.Right:Set(controls.abilities.Left)
     controls.abilityBG.BL.Top:Set(controls.abilities.Bottom)
-    
+
     controls.abilityBG.BM:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_lm.dds'))
     controls.abilityBG.BM.Right:Set(controls.abilityBG.BL.Right)
-    controls.abilityBG.BM.Top:Set(function() return controls.abilities.Bottom() end)
+    controls.abilityBG.BM.Top:Set(controls.abilities.Bottom)
     controls.abilityBG.BM.Left:Set(controls.abilityBG.BR.Left)
-    
+
     controls.abilityBG.BR:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_lr.dds'))
     controls.abilityBG.BR.Left:Set(controls.abilities.Right)
     controls.abilityBG.BR.Top:Set(controls.abilities.Bottom)
-
-    -- all these come from GAZ UI --
-    LayoutHelpers.AtLeftTopIn(controls.healthBar, controls.bg, 66, 25)
-    LayoutHelpers.Below(controls.shieldBar, controls.healthBar)
-    controls.shieldBar.Height:Set(14)
-    LayoutHelpers.CenteredBelow(controls.shieldText, controls.shieldBar,0)
-    controls.shieldBar.Height:Set(2)
-    LayoutHelpers.AtLeftTopIn(controls.statGroups[1].icon, controls.bg, 70, 55)
-    LayoutHelpers.RightOf(controls.statGroups[1].value, controls.statGroups[1].icon, 5)
-    LayoutHelpers.Below(controls.statGroups[2].icon, controls.statGroups[1].icon,0)
--- LayoutHelpers.AtRightTopIn(controls.StorageMass, controls.bg, 145, 55)
-    LayoutHelpers.RightOf(controls.statGroups[2].value, controls.statGroups[2].icon, 5)
--- LayoutHelpers.AtRightTopIn(controls.StorageEnergy, controls.bg, 145, 73)
-    LayoutHelpers.Below(controls.Buildrate, controls.statGroups[2].value,1)
-    LayoutHelpers.LeftOf(controls.BuildrateIcon, controls.Buildrate, 1)
 end
 
 function PositionWindow()
-
-    local controls = import('/lua/ui/game/unitview.lua').controls
-    local consControl = import('/lua/ui/game/construction.lua').controls.constructionGroup
     if consControl:IsHidden() then
         LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
         LayoutHelpers.AtLeftIn(controls.bg, consControl, 18)
@@ -173,5 +184,15 @@ function PositionWindow()
         LayoutHelpers.AtLeftTopIn(controls.bracket, controls.bg, -6, 3)
         LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
         LayoutHelpers.AtLeftIn(controls.bg, controls.parent, 207)
+    end
+end
+
+function UpdateStatusBars(controls)
+    if options.gui_detailed_unitview ~= 0 and controls.store == 1 then
+        LayoutHelpers.CenteredBelow(controls.fuelBar, controls.shieldBar,3)
+        LayoutHelpers.CenteredBelow(controls.shieldText, controls.fuelBar,-2.5)
+    elseif options.gui_detailed_unitview ~= 0 then
+        LayoutHelpers.CenteredBelow(controls.fuelBar, controls.shieldBar,0)
+        LayoutHelpers.CenteredBelow(controls.shieldText, controls.shieldBar,0)
     end
 end

--- a/gamedata/lua/lua/ui/game/layouts/unitview_mini.lua
+++ b/gamedata/lua/lua/ui/game/layouts/unitview_mini.lua
@@ -1,7 +1,9 @@
 local UIUtil = import('/lua/ui/uiutil.lua')
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
+local options = import("/lua/user/prefs.lua").GetFromCurrentProfile('options')
 local controls = import('/lua/ui/game/unitview.lua').controls
-local consControl = import("/lua/ui/game/construction.lua").controls.constructionGroup
+local consControl = import('/lua/ui/game/construction.lua').controls.constructionGroup
+local ordersControls = import('/lua/ui/game/orders.lua').controls
 
 local iconPositions = {
     [1] = {Left = 70, Top = 55},
@@ -28,10 +30,10 @@ function SetLayout()
     controls.bg:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/build-over-back_bmp.dds'))
     LayoutHelpers.AtLeftIn(controls.bg, controls.parent)
     LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
-    
+
     controls.bracket:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/bracket-unit_bmp.dds'))
     LayoutHelpers.AtLeftTopIn(controls.bracket, controls.bg, -18, -2)
-    
+
     if controls.bracketMid then
         controls.bracketMid:Destroy()
         controls.bracketMid = false
@@ -40,14 +42,14 @@ function SetLayout()
         controls.bracketMax:Destroy()
         controls.bracketMax = false
     end
-    
+
     LayoutHelpers.AtLeftTopIn(controls.name, controls.bg, 16, 14)
     LayoutHelpers.AtRightIn(controls.name, controls.bg, 16)
     controls.name:SetClipToWidth(true)
     controls.name:SetDropShadow(true)
-    
+
     LayoutHelpers.AtLeftTopIn(controls.icon, controls.bg, 12, 34)
-	LayoutHelpers.SetDimensions(controls.icon, 48, 48)
+    LayoutHelpers.SetDimensions(controls.icon, 48, 48)
     LayoutHelpers.AtLeftTopIn(controls.stratIcon, controls.icon)
     LayoutHelpers.Below(controls.vetIcons[1], controls.icon, 5)
     LayoutHelpers.AtLeftIn(controls.vetIcons[1], controls.icon, -5)
@@ -56,16 +58,16 @@ function SetLayout()
         LayoutHelpers.RightOf(controls.vetIcons[i], controls.vetIcons[i-1], -3)
     end
     LayoutHelpers.AtLeftTopIn(controls.healthBar, controls.bg, 66, 35)
-	LayoutHelpers.SetDimensions(controls.healthBar, 188, 16)
+    LayoutHelpers.SetDimensions(controls.healthBar, 188, 16)
     controls.healthBar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_bg.dds'))
     controls.healthBar._bar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_green.dds'))
     LayoutHelpers.AtBottomIn(controls.shieldBar, controls.healthBar)
     LayoutHelpers.AtLeftIn(controls.shieldBar, controls.healthBar)
-	LayoutHelpers.SetDimensions(controls.shieldBar, 188, 2)
+    LayoutHelpers.SetDimensions(controls.shieldBar, 188, 2)
     controls.shieldBar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_bg.dds'))
     controls.shieldBar._bar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/shieldbar.dds'))
     LayoutHelpers.Below(controls.fuelBar, controls.shieldBar)
-	LayoutHelpers.SetDimensions(controls.fuelBar, 188, 2)
+    LayoutHelpers.SetDimensions(controls.fuelBar, 188, 2)
     controls.fuelBar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_bg.dds'))
     controls.fuelBar._bar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/fuelbar.dds'))
 
@@ -81,7 +83,7 @@ function SetLayout()
 
     LayoutHelpers.AtCenterIn(controls.health, controls.healthBar)
     controls.health:SetDropShadow(true)
-    
+
     for index = 1, table.getn(iconPositions) do
         local i = index
         if iconPositions[i] then
@@ -95,81 +97,103 @@ function SetLayout()
         controls.statGroups[i].value:SetDropShadow(true)
     end
     LayoutHelpers.AtLeftTopIn(controls.actionIcon, controls.bg, 261, 34)
-	LayoutHelpers.SetDimensions(controls.actionIcon, 48, 48)
+    LayoutHelpers.SetDimensions(controls.actionIcon, 48, 48)
     LayoutHelpers.Below(controls.actionText, controls.actionIcon)
     LayoutHelpers.AtHorizontalCenterIn(controls.actionText, controls.actionIcon)
-    
+
     LayoutHelpers.AnchorToRight(controls.abilities, controls.bg, 19)
     LayoutHelpers.AtBottomIn(controls.abilities, controls.bg, 50)
-	LayoutHelpers.SetDimensions(controls.abilities, 200, 50)
-    
+    LayoutHelpers.SetDimensions(controls.abilities, 200, 50)
+
+    SetBG(controls)
+
+    if options.gui_detailed_unitview ~= 0 then
+        LayoutHelpers.AtLeftTopIn(controls.healthBar, controls.bg, 66, 25)
+        LayoutHelpers.Below(controls.shieldBar, controls.healthBar)
+        LayoutHelpers.SetHeight(controls.shieldBar, 14)
+        LayoutHelpers.CenteredBelow(controls.shieldText, controls.shieldBar,0)
+        LayoutHelpers.SetHeight(controls.shieldBar, 2)
+    else
+        LayoutHelpers.AtLeftTopIn(controls.statGroups[1].icon, controls.bg, 70, 60)
+        LayoutHelpers.AtLeftTopIn(controls.statGroups[2].icon, controls.bg, 70, 80)
+    end
+
+    -- all this from GAZ UI --
+--    LayoutHelpers.AtLeftTopIn(controls.healthBar, controls.bg, 66, 25)
+--    LayoutHelpers.Below(controls.shieldBar, controls.healthBar)
+--    LayoutHelpers.SetHeight(controls.shieldBar, 14)
+--    LayoutHelpers.CenteredBelow(controls.shieldText, controls.shieldBar, 0)
+--    LayoutHelpers.SetHeight(controls.shieldBar, 2)
+end
+
+function SetBG(controls)
     controls.abilityBG.TL:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_ul.dds'))
     controls.abilityBG.TL.Right:Set(controls.abilities.Left)
     controls.abilityBG.TL.Bottom:Set(controls.abilities.Top)
-    
+
     controls.abilityBG.TM:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_horz_um.dds'))
     controls.abilityBG.TM.Right:Set(controls.abilityBG.TL.Right)
     controls.abilityBG.TM.Bottom:Set(controls.abilities.Top)
     controls.abilityBG.TM.Left:Set(controls.abilityBG.TR.Left)
-    
+
     controls.abilityBG.TR:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_ur.dds'))
     controls.abilityBG.TR.Left:Set(controls.abilities.Right)
     controls.abilityBG.TR.Bottom:Set(controls.abilities.Top)
-    
+
     controls.abilityBG.ML:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_vert_l.dds'))
     controls.abilityBG.ML.Right:Set(controls.abilities.Left)
     controls.abilityBG.ML.Top:Set(controls.abilityBG.TL.Bottom)
     controls.abilityBG.ML.Bottom:Set(controls.abilityBG.BL.Top)
-    
+
     controls.abilityBG.M:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_m.dds'))
     controls.abilityBG.M.Top:Set(controls.abilityBG.TM.Bottom)
     controls.abilityBG.M.Left:Set(controls.abilityBG.ML.Right)
     controls.abilityBG.M.Right:Set(controls.abilityBG.MR.Left)
     controls.abilityBG.M.Bottom:Set(controls.abilityBG.BM.Top)
-    
+
     controls.abilityBG.MR:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_vert_r.dds'))
     controls.abilityBG.MR.Left:Set(controls.abilities.Right)
     controls.abilityBG.MR.Top:Set(controls.abilityBG.TR.Bottom)
     controls.abilityBG.MR.Bottom:Set(controls.abilityBG.BR.Top)
-    
+
     controls.abilityBG.BL:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_ll.dds'))
     controls.abilityBG.BL.Right:Set(controls.abilities.Left)
     controls.abilityBG.BL.Top:Set(controls.abilities.Bottom)
-    
+
     controls.abilityBG.BM:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_lm.dds'))
     controls.abilityBG.BM.Right:Set(controls.abilityBG.BL.Right)
     controls.abilityBG.BM.Top:Set(controls.abilities.Bottom)
     controls.abilityBG.BM.Left:Set(controls.abilityBG.BR.Left)
-    
+
     controls.abilityBG.BR:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_lr.dds'))
     controls.abilityBG.BR.Left:Set(controls.abilities.Right)
     controls.abilityBG.BR.Top:Set(controls.abilities.Bottom)
-    
-    -- all this from GAZ UI --
-    LayoutHelpers.AtLeftTopIn(controls.healthBar, controls.bg, 66, 25)
-    LayoutHelpers.Below(controls.shieldBar, controls.healthBar)
-    LayoutHelpers.SetHeight(controls.shieldBar, 14)
-    LayoutHelpers.CenteredBelow(controls.shieldText, controls.shieldBar, 0)
-	LayoutHelpers.SetHeight(controls.shieldBar, 2)
 end
 
 function PositionWindow()
     if consControl:IsHidden() then
         LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
-		LayoutHelpers.AtBottomIn(controls.abilities, controls.bg, 24)
+        LayoutHelpers.AtBottomIn(controls.abilities, controls.bg, 24)
     else
-        LayoutHelpers.AtBottomIn(controls.bg, controls.parent, 120)
-		LayoutHelpers.AtBottomIn(controls.abilities, controls.bg, 42)
+        if ordersControls.bg then
+            LayoutHelpers.AtBottomIn(controls.bg, controls.parent, 120)
+            LayoutHelpers.AtBottomIn(controls.abilities, controls.bg, 42)
+        else
+            -- Replay? Anyway, the orders control does not exist so the construction control is all the way to the left.
+            -- The construction control is taller than the orders control, so we have to move unit view higher.
+            LayoutHelpers.AtBottomIn(controls.bg, controls.parent, 140)
+            LayoutHelpers.AtLeftIn(controls.bg, controls.parent, 18)
+        end
     end
-	LayoutHelpers.AtLeftIn(controls.bg, controls.parent, 17)
+    LayoutHelpers.AtLeftIn(controls.bg, controls.parent, 17)
 end
 
 function UpdateStatusBars(controls)
-    if controls.store == 1 then
-        LayoutHelpers.CenteredBelow(controls.fuelBar, controls.shieldBar, 3)
-        LayoutHelpers.CenteredBelow(controls.shieldText, controls.fuelBar, -2.5)
-    else
-        LayoutHelpers.CenteredBelow(controls.fuelBar, controls.shieldBar, 0)
-        LayoutHelpers.CenteredBelow(controls.shieldText, controls.shieldBar, 0)
+    if options.gui_detailed_unitview ~= 0 and controls.store == 1 then
+        LayoutHelpers.CenteredBelow(controls.fuelBar, controls.shieldBar,3)
+        LayoutHelpers.CenteredBelow(controls.shieldText, controls.fuelBar,-2.5)
+    elseif options.gui_detailed_unitview ~= 0 then
+        LayoutHelpers.CenteredBelow(controls.fuelBar, controls.shieldBar,0)
+        LayoutHelpers.CenteredBelow(controls.shieldText, controls.shieldBar,0)
     end
 end

--- a/gamedata/lua/lua/ui/game/layouts/unitview_right.lua
+++ b/gamedata/lua/lua/ui/game/layouts/unitview_right.lua
@@ -1,17 +1,38 @@
-
 local UIUtil = import('/lua/ui/uiutil.lua')
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
+local options = import('/lua/user/prefs.lua').GetFromCurrentProfile('options')
+local controls = import('/lua/ui/game/unitview.lua').controls
+local consControl = import('/lua/ui/game/construction.lua').controls.constructionGroup
+
+local iconPositions = {
+    [1] = {Left = 70, Top = 55},
+    [2] = {Left = 70, Top = 70},
+    [3] = {Left = 190, Top = 60},
+    [4] = {Left = 130, Top = 55},
+    [5] = {Left = 130, Top = 85},
+    [6] = {Left = 130, Top = 70},
+    [7] = {Left = 190, Top = 85},
+    [8] = {Left = 70, Top = 85},
+}
+local iconTextures = {
+    UIUtil.UIFile('/game/unit_view_icons/mass.dds'),
+    UIUtil.UIFile('/game/unit_view_icons/energy.dds'),
+    UIUtil.UIFile('/game/unit_view_icons/kills.dds'),
+    UIUtil.UIFile('/game/unit_view_icons/kills.dds'),
+    UIUtil.UIFile('/game/unit_view_icons/missiles.dds'),
+    UIUtil.UIFile('/game/unit_view_icons/shield.dds'),
+    UIUtil.UIFile('/game/unit_view_icons/fuel.dds'),
+    UIUtil.UIFile('/game/unit_view_icons/build.dds'),
+}
 
 function SetLayout()
-
-    local controls = import('/lua/ui/game/unitview.lua').controls
     controls.bg:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/build-over-back_bmp.dds'))
     LayoutHelpers.AtLeftIn(controls.bg, controls.parent)
     LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
-    
+
     controls.bracket:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/bracket-unit_bmp.dds'))
     LayoutHelpers.AtLeftTopIn(controls.bracket, controls.bg, -19, -2)
-    
+
     if controls.bracketMid then
         controls.bracketMid:Destroy()
         controls.bracketMid = false
@@ -20,15 +41,14 @@ function SetLayout()
         controls.bracketMax:Destroy()
         controls.bracketMax = false
     end
-    
+
     LayoutHelpers.AtLeftTopIn(controls.name, controls.bg, 16, 14)
     LayoutHelpers.AtRightIn(controls.name, controls.bg, 16)
     controls.name:SetClipToWidth(true)
     controls.name:SetDropShadow(true)
-    
+
     LayoutHelpers.AtLeftTopIn(controls.icon, controls.bg, 12, 34)
-    controls.icon.Height:Set(48)
-    controls.icon.Width:Set(48)
+    LayoutHelpers.SetDimensions(controls.icon, 48, 48)
     LayoutHelpers.AtLeftTopIn(controls.stratIcon, controls.icon)
     LayoutHelpers.Below(controls.vetIcons[1], controls.icon, 5)
     LayoutHelpers.AtLeftIn(controls.vetIcons[1], controls.icon, -5)
@@ -37,38 +57,33 @@ function SetLayout()
         LayoutHelpers.RightOf(controls.vetIcons[i], controls.vetIcons[i-1], -3)
     end
     LayoutHelpers.AtLeftTopIn(controls.healthBar, controls.bg, 66, 35)
-    controls.healthBar.Width:Set(188)
-    controls.healthBar.Height:Set(16)
+    LayoutHelpers.SetDimensions(controls.healthBar, 188, 16)
     controls.healthBar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_bg.dds'))
     controls.healthBar._bar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_green.dds'))
     LayoutHelpers.AtBottomIn(controls.shieldBar, controls.healthBar)
     LayoutHelpers.AtLeftIn(controls.shieldBar, controls.healthBar)
-    controls.shieldBar.Width:Set(188)
-    controls.shieldBar.Height:Set(2)
+    LayoutHelpers.SetDimensions(controls.shieldBar, 188, 2)
     controls.shieldBar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_bg.dds'))
     controls.shieldBar._bar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/shieldbar.dds'))
     LayoutHelpers.Below(controls.fuelBar, controls.shieldBar)
-    controls.fuelBar.Width:Set(188)
-    controls.fuelBar.Height:Set(2)
+    LayoutHelpers.SetDimensions(controls.fuelBar, 188, 2)
     controls.fuelBar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_bg.dds'))
     controls.fuelBar._bar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/fuelbar.dds'))
+
+    LayoutHelpers.AtLeftTopIn(controls.vetBar, controls.bg, 192, 68)
+    LayoutHelpers.SetDimensions(controls.vetBar, 56, 3)
+    controls.vetBar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_bg.dds'))
+    controls.vetBar._bar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/fuelbar.dds'))
+
+    LayoutHelpers.Below(controls.nextVet, controls.vetBar)
+    controls.nextVet:SetDropShadow(true)
+    LayoutHelpers.Above(controls.vetTitle, controls.vetBar)
+    controls.vetTitle:SetDropShadow(true)
+
     LayoutHelpers.AtCenterIn(controls.health, controls.healthBar)
     controls.health:SetDropShadow(true)
-    
-    local iconPositions = {
-        [1] = {Left = 70, Top = 60},
-        [3] = {Left = 140, Top = 60},
-        [5] = {Left = 190, Top = 60},
-    }
-    local iconTextures = {
-        UIUtil.UIFile('/game/unit_view_icons/mass.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/energy.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/kills.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/missiles.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/shield.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/fuel.dds'),
-    }
-    for index = 1, 6 do
+
+    for index = 1, table.getn(iconPositions) do
         local i = index
         if iconPositions[i] then
             LayoutHelpers.AtLeftTopIn(controls.statGroups[i].icon, controls.bg, iconPositions[i].Left, iconPositions[i].Top)
@@ -81,84 +96,88 @@ function SetLayout()
         controls.statGroups[i].value:SetDropShadow(true)
     end
     LayoutHelpers.AtLeftTopIn(controls.actionIcon, controls.bg, 261, 34)
-    controls.actionIcon.Height:Set(48)
-    controls.actionIcon.Width:Set(48)
+    LayoutHelpers.SetDimensions(controls.actionIcon, 48, 48)
     LayoutHelpers.Below(controls.actionText, controls.actionIcon)
     LayoutHelpers.AtHorizontalCenterIn(controls.actionText, controls.actionIcon)
-    
-    controls.abilities.Left:Set(function() return controls.bg.Right() + 20 end)
-    controls.abilities.Bottom:Set(function() return controls.bg.Bottom() - 24 end)
-    controls.abilities.Height:Set(50)
-    controls.abilities.Width:Set(200)
-    
+
+    LayoutHelpers.AnchorToRight(controls.abilities, controls.bg, 20)
+    LayoutHelpers.AtBottomIn(controls.abilities, controls.bg, 24)
+    LayoutHelpers.SetDimensions(controls.abilities, 200, 50)
+
+    SetBG(controls)
+
+    if options.gui_detailed_unitview ~= 0 then
+        LayoutHelpers.AtLeftTopIn(controls.healthBar, controls.bg, 66, 25)
+        LayoutHelpers.Below(controls.shieldBar, controls.healthBar)
+        LayoutHelpers.SetHeight(controls.shieldBar, 14)
+        LayoutHelpers.CenteredBelow(controls.shieldText, controls.shieldBar,0)
+        LayoutHelpers.SetHeight(controls.shieldBar, 2)
+    else
+        LayoutHelpers.AtLeftTopIn(controls.statGroups[1].icon, controls.bg, 70, 60)
+        LayoutHelpers.AtLeftTopIn(controls.statGroups[2].icon, controls.bg, 70, 80)
+    end
+end
+
+function SetBG(controls)
     controls.abilityBG.TL:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_ul.dds'))
     controls.abilityBG.TL.Right:Set(controls.abilities.Left)
     controls.abilityBG.TL.Bottom:Set(controls.abilities.Top)
-    
+
     controls.abilityBG.TM:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_horz_um.dds'))
     controls.abilityBG.TM.Right:Set(controls.abilityBG.TL.Right)
-    controls.abilityBG.TM.Bottom:Set(function() return controls.abilities.Top() end)
+    controls.abilityBG.TM.Bottom:Set(controls.abilities.Top)
     controls.abilityBG.TM.Left:Set(controls.abilityBG.TR.Left)
-    
+
     controls.abilityBG.TR:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_ur.dds'))
     controls.abilityBG.TR.Left:Set(controls.abilities.Right)
     controls.abilityBG.TR.Bottom:Set(controls.abilities.Top)
-    
+
     controls.abilityBG.ML:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_vert_l.dds'))
     controls.abilityBG.ML.Right:Set(controls.abilities.Left)
     controls.abilityBG.ML.Top:Set(controls.abilityBG.TL.Bottom)
     controls.abilityBG.ML.Bottom:Set(controls.abilityBG.BL.Top)
-    
+
     controls.abilityBG.M:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_m.dds'))
     controls.abilityBG.M.Top:Set(controls.abilityBG.TM.Bottom)
     controls.abilityBG.M.Left:Set(controls.abilityBG.ML.Right)
     controls.abilityBG.M.Right:Set(controls.abilityBG.MR.Left)
     controls.abilityBG.M.Bottom:Set(controls.abilityBG.BM.Top)
-    
+
     controls.abilityBG.MR:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_vert_r.dds'))
     controls.abilityBG.MR.Left:Set(controls.abilities.Right)
     controls.abilityBG.MR.Top:Set(controls.abilityBG.TR.Bottom)
     controls.abilityBG.MR.Bottom:Set(controls.abilityBG.BR.Top)
-    
+
     controls.abilityBG.BL:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_ll.dds'))
     controls.abilityBG.BL.Right:Set(controls.abilities.Left)
     controls.abilityBG.BL.Top:Set(controls.abilities.Bottom)
-    
+
     controls.abilityBG.BM:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_lm.dds'))
     controls.abilityBG.BM.Right:Set(controls.abilityBG.BL.Right)
-    controls.abilityBG.BM.Top:Set(function() return controls.abilities.Bottom() end)
+    controls.abilityBG.BM.Top:Set(controls.abilities.Bottom)
     controls.abilityBG.BM.Left:Set(controls.abilityBG.BR.Left)
-    
+
     controls.abilityBG.BR:SetTexture(UIUtil.UIFile('/game/filter-ping-list-panel/panel_brd_lr.dds'))
     controls.abilityBG.BR.Left:Set(controls.abilities.Right)
     controls.abilityBG.BR.Top:Set(controls.abilities.Bottom)
-    
-    -- all this from GAZ UI
-    LayoutHelpers.AtLeftTopIn(controls.healthBar, controls.bg, 66, 25)
-    LayoutHelpers.Below(controls.shieldBar, controls.healthBar)
-    controls.shieldBar.Height:Set(14)
-    LayoutHelpers.CenteredBelow(controls.shieldText, controls.shieldBar,0)
-    controls.shieldBar.Height:Set(2)
-    LayoutHelpers.AtLeftTopIn(controls.statGroups[1].icon, controls.bg, 70, 55)
-    LayoutHelpers.RightOf(controls.statGroups[1].value, controls.statGroups[1].icon, 5)
-    LayoutHelpers.Below(controls.statGroups[2].icon, controls.statGroups[1].icon,0)
--- LayoutHelpers.AtRightTopIn(controls.StorageMass, controls.bg, 145, 55)
-    LayoutHelpers.RightOf(controls.statGroups[2].value, controls.statGroups[2].icon, 5)
--- LayoutHelpers.AtRightTopIn(controls.StorageEnergy, controls.bg, 145, 73)
-    LayoutHelpers.Below(controls.Buildrate, controls.statGroups[2].value,1)
-    LayoutHelpers.LeftOf(controls.BuildrateIcon, controls.Buildrate, 1)
 end
 
 function PositionWindow()
-
-    local controls = import('/lua/ui/game/unitview.lua').controls
-    local consControl = import('/lua/ui/game/construction.lua').controls.constructionGroup
-    
     if consControl:IsHidden() then
         LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
         LayoutHelpers.AtLeftIn(controls.bg, controls.parent, 18)
     else
         LayoutHelpers.AtBottomIn(controls.bg, controls.parent, 140)
         LayoutHelpers.AtLeftIn(controls.bg, controls.parent, 18)
+    end
+end
+
+function UpdateStatusBars(controls)
+    if options.gui_detailed_unitview ~= 0 and controls.store == 1 then
+        LayoutHelpers.CenteredBelow(controls.fuelBar, controls.shieldBar,3)
+        LayoutHelpers.CenteredBelow(controls.shieldText, controls.fuelBar,-2.5)
+    elseif options.gui_detailed_unitview ~= 0 then
+        LayoutHelpers.CenteredBelow(controls.fuelBar, controls.shieldBar,0)
+        LayoutHelpers.CenteredBelow(controls.shieldText, controls.shieldBar,0)
     end
 end


### PR DESCRIPTION
- Fixed the pause and repeat buttons not being displayed in the construction panel when switching from the enhancements view to the construction view
- Fixed misplacement of buttons in left and right layouts
- Added support for UI scaling in left and right layouts
- Fixed that the edges of the minimap were cut off too much at higher UI scaling factors
- Removed some unused local variables
- Removed some unnecessary spaces
- Replaced some tabs by spaces
- Corrected some carriage return line feeds