### PR TITLE
Fixed and optimised broken unused function

### DIFF
--- a/gamedata/lua/lua/utilities.lua
+++ b/gamedata/lua/lua/utilities.lua
@@ -62,7 +62,10 @@ function GetEnemyUnitsInSphere(unit, position, radius)
 end
 
 function GetDistanceBetweenTwoPoints(x1, y1, z1, x2, y2, z2)
-    return ( LOUDSQRT( (x1-x2)^2 + (y1-y2)^2 + (z1-z2)^2 ) )
+	local a = (x1-x2)
+	local b = (y1-y2)
+	local c = (z1-z2)
+	return ( LOUDSQRT( a*a + b*b + c*c ) )
 end
 
 function GetDistanceBetweenTwoVectors( v1, v2 )


### PR DESCRIPTION
`^` is a bitwise opperation, not power. The function appears unused anyway, but it would've given hilariously wrong values.