### PR TITLE
A few small improvements in the chat panel

### DIFF
--- a/gamedata/LOUD_Misc/mods/SupremeScoreBoard/hook/lua/ui/game/score.lua
+++ b/gamedata/LOUD_Misc/mods/SupremeScoreBoard/hook/lua/ui/game/score.lua
@@ -600,7 +600,7 @@ local function SendResource(armyTarget, mass, energy)
     end
     if sentAmount > 1 then
         local armyName = Stats.armies[armyTarget].nickname 
-        SendMessage('sent ' .. sentResource .. ' to \n ' .. armyName .. '') 
+        SendMessage('sent ' .. sentResource .. ' to ' .. armyName .. '')
 
         SimCallback( { Func = "GiveResourcesToPlayer",
                    Args = { From = armySender, To = armyTarget, 
@@ -633,7 +633,7 @@ local function SendUnits(armyTarget, allUnits)
 
     if units > 0 then 
         local armyName = Stats.armies[armyTarget].nickname  
-        SendMessage('sent '..units..' units to \n ' .. armyName .. '' ) 
+        SendMessage('sent '..units..' units to ' .. armyName .. '' )
     end 
 end
 

--- a/gamedata/lua/lua/maui/window.lua
+++ b/gamedata/lua/lua/maui/window.lua
@@ -556,7 +556,18 @@ Window = Class(Group) {
             end
         end
     end,
-    
+
+    ---@param self Window
+    ---@param alpha number
+    ---@param affectChildren boolean
+    SetAlpha = function(self, alpha, affectChildren)
+        affectChildren = affectChildren or false
+        Group.SetAlpha(self, alpha, affectChildren)
+
+        -- guarantee that the resize bars remain transparent
+        self._resizeGroup:SetAlpha(0, true)
+    end,
+
     SaveWindowLocation = function(self)
         if self._pref then
             Prefs.SetToCurrentProfile(

--- a/gamedata/lua/lua/ui/game/chat.lua
+++ b/gamedata/lua/lua/ui/game/chat.lua
@@ -396,7 +396,8 @@ function SetupChatScroll()
     
     -- determines what controls should be visible or not
     GUI.chatContainer.CalcVisible = function(self)
-	
+        GUI.chatContainer.scroll:SetAlpha(ChatOptions.win_alpha, true)
+
         GUI.bg.curTime = 0
 		
         local index = 1

--- a/gamedata/lua/lua/ui/game/chat.lua
+++ b/gamedata/lua/lua/ui/game/chat.lua
@@ -151,7 +151,7 @@ function CreateChatBackground()
     
     Tooltip.AddButtonTooltip(bg.ResetPositionBtn, 'chat_reset')    
     
-    bg:SetMinimumResize(LayoutHelpers.ScaleNumber(400), LayoutHelpers.ScaleNumber(160))
+    bg:SetMinimumResize(400, 160)
     return bg
 end
 


### PR DESCRIPTION
- Fixes the double scaling of the minimum chat panel size
- Apply alpha setting also to the scrollbar in chat panel
- Removes the thin gray frame around the chat panel
- Removes the line break in the chat message “sent XXX to YYY” when sharing resources