### PR TITLE
mTMD and mSMD Veteran Removal

### DIFF
--- a/gamedata/BrewLAN_LOUD/mods/BrewLAN_LOUD/units/SRL0321/SRL0321_unit.bp
+++ b/gamedata/BrewLAN_LOUD/mods/BrewLAN_LOUD/units/SRL0321/SRL0321_unit.bp
@@ -152,14 +152,6 @@ UnitBlueprint {
         TransportClass = 3,
     },
 	
-    Veteran = {
-        Level1 = 6,
-        Level2 = 12,
-        Level3 = 18,
-        Level4 = 24,
-        Level5 = 30,
-    },
-	
     Weapon = {
         {
             AlwaysRecheckTarget = false,

--- a/gamedata/BrewLAN_LOUD/mods/BrewLAN_LOUD/units/SSL0321/SSL0321_unit.bp
+++ b/gamedata/BrewLAN_LOUD/mods/BrewLAN_LOUD/units/SSL0321/SSL0321_unit.bp
@@ -181,14 +181,6 @@ UnitBlueprint {
         TransportClass = 3,
     },
 	
-    Veteran = {
-        Level1 = 6,
-        Level2 = 12,
-        Level3 = 18,
-        Level4 = 24,
-        Level5 = 30,
-    },
-	
     Weapon = {
         {
             AnimationReload = '/units/xsl0111/xsl0111_areload.sca',

--- a/gamedata/WyvernBattlePack/mods/BattlePack/units/WEL0207/WEL0207_unit.bp
+++ b/gamedata/WyvernBattlePack/mods/BattlePack/units/WEL0207/WEL0207_unit.bp
@@ -36,7 +36,7 @@ UnitBlueprint{
         SurfaceThreatLevel = 0.1,
     },
 
-    Description = "Mobile Tac-Missile Defense",
+    Description = "Mobile Tactical Missile Defense",
 
     Display = {
         Abilities = { "<LOC ability_tacmissiledef>Tactical Missile Defense" },
@@ -119,14 +119,6 @@ UnitBlueprint{
     StrategicIconSortPriority = 125,
 
     Transport = { TransportClass = 2 },
-
-    Veteran = {
-        Level1 = 6,
-        Level2 = 12,
-        Level3 = 18,
-        Level4 = 24,
-        Level5 = 30,
-    },
 
     Weapon = {
         {


### PR DESCRIPTION
* Veteran field removed from Cybran Hedgehog and Seraphim Ythhu: T3 Mobile Strategic Missile Defense (srl0321 and ssl0321) as it's not needed.
* Veteran field removed from UEF Sharp Shooter: T2 Mobile Tactical Missile Defense (wel0207) as it's not needed.