### PR TITLE
Settings added to MassRandom Normal (0-4) x Enchanced (9)

### DIFF
--- a/gamedata/LOUD_Misc/mods/BrewLAN_Gameplay/MassRandom/config.lua
+++ b/gamedata/LOUD_Misc/mods/BrewLAN_Gameplay/MassRandom/config.lua
@@ -1,0 +1,17 @@
+config = {
+	{   
+        default = 1,
+        label = "Mass Point Distribution",
+        key = 'MassDistribution',
+        values = {
+            {
+                text = "Normal (0-4 points)",
+                key = 'Normal',
+            },
+            {
+                text = "Enhanced (9 points)",
+                key = 'Enhanced',
+            },
+        },
+    },
+}

--- a/gamedata/LOUD_Misc/mods/BrewLAN_Gameplay/MassRandom/hook/lua/sim/ScenarioUtilities.lua
+++ b/gamedata/LOUD_Misc/mods/BrewLAN_Gameplay/MassRandom/hook/lua/sim/ScenarioUtilities.lua
@@ -1,0 +1,34 @@
+-- Hook for Mass Point RNG mod
+-- This modifies the coordsTbl based on mod configuration
+
+do
+    local OldCreateResources = CreateResources
+
+    function CreateResources()
+        
+        -- Check if MassPointRNG is enabled and get mod config
+        if ScenarioInfo.MassPointRNG then
+            
+            local modConfig = {}
+            
+            -- Find the MassRandom mod config
+            for _, v in __active_mods do
+                if v.uid == '25D57D85-7D84-27HT-A502-MASSRNG00002' then
+                    modConfig = v.config
+                    break
+                end
+            end
+            
+            -- Get the selected distribution type
+            local distributionType = modConfig['MassDistribution'] or 'Normal'
+            
+            LOG("*AI DEBUG Mass Point RNG Distribution Type: " .. distributionType)
+            
+            -- Store the distribution type for use in CreateResources
+            ScenarioInfo.MassDistributionType = distributionType
+        end
+        
+        -- Call the original function
+        OldCreateResources()
+    end
+end

--- a/gamedata/LOUD_Misc/mods/BrewLAN_Gameplay/MassRandom/mod_info.lua
+++ b/gamedata/LOUD_Misc/mods/BrewLAN_Gameplay/MassRandom/mod_info.lua
@@ -1,8 +1,8 @@
 name = "Mass Point RNG"
 uid = "25D57D85-7D84-27HT-A502-MASSRNG00002"
-version = 0.3
+version = 0.4
 copyright = "© 2018 Sean Wheeldon"
-description = "Each mass point is replaced with 0-4 mass points."
+description = "Each mass point is replaced with 0-4 mass points (Normal) or 9 mass points (Enhanced)."
 author = "Balthazar"
 icon = "/mods/BrewLAN_Gameplay/MassRandom/MassRandom.png"
 selectable = true

--- a/gamedata/lua/lua/sim/ScenarioUtilities.lua
+++ b/gamedata/lua/lua/sim/ScenarioUtilities.lua
@@ -237,27 +237,38 @@ function CreateResources()
     if ScenarioInfo.MassPointRNG then
         LOG("*AI DEBUG MassPointRNG DETECTED")
         
-        -- replace coordsTbl with data --
-        -- randomly selected
-        coordsTbl = {
-            { {-2,-2}, {-2, 2}, { 2,-2}, { 2, 2}    },
-            { {-2, 0}, { 0,-2}, { 2, 0}, { 0, 2}    },
-            { { 0, 0}, {-2, 2}, { 2, 2}     },
-            { {-2, 0}, { 0, 0}, { 2, 0}     },
-            { { 0,-2}, { 0, 0}, { 0, 2}     },  
-            { { 0,-2}, { 0, 2}  },
-            { {-2, 0}, { 2, 0}  },
-            { { 1, 1}, {-1,-1}  },
-            { {-1, 1}, { 1,-1}  },
-            { { 0, 0}   },
-            { { 2, 0}   },
-            { {-2, 0}   },
-            { { 0,-2}   },
-            { { 0, 2}   },
-            { },
-            { },
-            { },
-        } 
+        -- Check if Enhanced mode is selected
+        local distributionType = ScenarioInfo.MassDistributionType or 'Normal'
+        
+        if distributionType == 'Enhanced' then
+            LOG("*AI DEBUG MassPointRNG - Enhanced mode (9 points)")
+            -- Enhanced mode: replace each point with 9 mass points
+            coordsTbl = {
+                { {-2,-2}, {-2, 2}, { 0, 0}, { 2,-2}, { 2, 2}, {-4, 0}, { 4, 0}, { 0,-4}, { 0, 4} },
+            }
+        else
+            LOG("*AI DEBUG MassPointRNG - Normal mode (0-4 points)")
+            -- Normal mode: replace coordsTbl with data randomly selected
+            coordsTbl = {
+                { {-2,-2}, {-2, 2}, { 2,-2}, { 2, 2}    },
+                { {-2, 0}, { 0,-2}, { 2, 0}, { 0, 2}    },
+                { { 0, 0}, {-2, 2}, { 2, 2}     },
+                { {-2, 0}, { 0, 0}, { 2, 0}     },
+                { { 0,-2}, { 0, 0}, { 0, 2}     },  
+                { { 0,-2}, { 0, 2}  },
+                { {-2, 0}, { 2, 0}  },
+                { { 1, 1}, {-1,-1}  },
+                { {-1, 1}, { 1,-1}  },
+                { { 0, 0}   },
+                { { 2, 0}   },
+                { {-2, 0}   },
+                { { 0,-2}   },
+                { { 0, 2}   },
+                { },
+                { },
+                { },
+            }
+        end
     end
     
     -- create the initial mass point list


### PR DESCRIPTION
This pull request introduces a new configuration option for the Mass Point RNG mod, allowing players to choose between "Normal" (0-4 points) and "Enhanced" (9 points) mass point distribution modes. The changes update the mod's configuration, hook into the resource creation logic to apply the selected distribution, and improve the mod description and version.

**New configuration and mode selection:**

* Added a `config.lua` file to define selectable mass point distribution modes ("Normal" and "Enhanced") for the mod.
* Updated `mod_info.lua` to reflect the new version (0.4) and describe both distribution modes in the mod description.

**Integration with resource creation logic:**

* Hooked `CreateResources` in `ScenarioUtilities.lua` to detect the selected distribution mode from the mod configuration and store it in `ScenarioInfo` for use during resource generation.
* Modified the main `CreateResources` function to generate mass points according to the selected mode: "Enhanced" mode creates 9 mass points per location, while "Normal" mode retains the original randomization logic. [[1]](diffhunk://#diff-711a6ea14fed87342ac4cb6e372a862c335aaebc94965283075b18b97c3896dfL240-R251) [[2]](diffhunk://#diff-711a6ea14fed87342ac4cb6e372a862c335aaebc94965283075b18b97c3896dfR272)

Mod Manager Config:
<img width="1368" height="795" alt="image" src="https://github.com/user-attachments/assets/90674d86-b232-451a-9274-edb217261b5f" />

Test 'Normal' Option:
<img width="1365" height="799" alt="image" src="https://github.com/user-attachments/assets/16496bd2-c085-4edf-a454-60ff142e208c" />

Test 'Enchanced' Option:
<img width="1370" height="800" alt="image" src="https://github.com/user-attachments/assets/3575fb65-86de-4aa2-a923-21e16fa56f9c" />