### PR TITLE
Update to the Stratigic Icon for Cybran T4 Bombardment ship

### DIFF
--- a/gamedata/BlackOps/mods/BlackOpsUnleashed/units/XRS0402/XRS0402_unit.bp
+++ b/gamedata/BlackOps/mods/BlackOpsUnleashed/units/XRS0402/XRS0402_unit.bp
@@ -180,7 +180,7 @@ UnitBlueprint {
     SizeY = 1.55,
     SizeZ = 10.8,
 	
-    StrategicIconName = 'icon_ship4_directfire',
+    StrategicIconName = 'icon_ship4_artillery',
     StrategicIconSortPriority = 145,
 	
     Veteran = {
@@ -1207,3 +1207,4 @@ UnitBlueprint {
         },				
     },
 }
+


### PR DESCRIPTION
Previously labled as "Direct Fire" the ship's main DPS, and, purpose, is bombardment. with its high arching shots, AND, said projectiles providing the most DPS. 

I feel that, while the ship does have good Directfire Capabilities, it, by name and design, is not its intended purpose.