### PR TITLE
Wyvern Star Adder Flamethrower Update

### DIFF
--- a/gamedata/WyvernBattlePack/mods/BattlePack/units/WEL4404/WEL4404_unit.bp
+++ b/gamedata/WyvernBattlePack/mods/BattlePack/units/WEL4404/WEL4404_unit.bp
@@ -480,7 +480,7 @@ UnitBlueprint{
             },
             RackReloadTimeout = 10,
 
-            RangeCategory = "UWRC_AntiNavy",
+            RangeCategory = "UWRC_Countermeasure",
 
             RateOfFire = 0.4,           -- potentially 1000 damage every 2.5 seconds = 400 DPS
 


### PR DESCRIPTION
* Changed RangeCategory for Flamethrower weapon on Star Adder (wel4404) to UWRC_Countermeasure