### PR TITLE
Added "Paragon"s to SupremeEconomy.

### DIFF
--- a/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/resourceusage.lua
+++ b/gamedata/LOUD_Misc/mods/SupremeEconomy/modules/resourceusage.lua
@@ -42,6 +42,7 @@ local maxImages = 5
 local grid = {}
 
 local unitClasses = {
+	{name="Paragon", category = categories.seb1401 + categories.xab1401 + categories.srb1401 + categories.ssb1401},
 	{name="T1 Land Units",  category = categories.LAND * categories.BUILTBYTIER1FACTORY * categories.MOBILE - categories.ENGINEER },
 	{name="T2 Land Units",  category = categories.LAND * categories.BUILTBYTIER2FACTORY * categories.MOBILE - categories.ENGINEER },
 	{name="T3 Land Units",  category = categories.LAND * categories.BUILTBYTIER3FACTORY * categories.MOBILE - categories.ENGINEER },


### PR DESCRIPTION
This change:

> {name="Paragon",  category = categories.seb1401 + categories.xab1401 + categories.srb1401 + categories.ssb1401}

when placed at the top of the unitClasses, just lables the Paragon seperately from other Energy and Mass producing structures your building, so you arent dumping 200+ mass into producing 'energy production'