### PR TITLE
BO ACU Enhancement Corrections

### DIFF
--- a/gamedata/BlackOps/mods/BlackopsACUs/units/EAL0001/EAL0001_unit.bp
+++ b/gamedata/BlackOps/mods/BlackopsACUs/units/EAL0001/EAL0001_unit.bp
@@ -301,7 +301,7 @@ UnitBlueprint {
 			
             Prerequisite = 'EXImprovedEngineering',
 
-            RemoveEnhancements = { 'EXImprovedEngineering','EXImprovedEngineeringRemove'},
+            RemoveEnhancements = {'EXImprovedEngineering','EXImprovedEngineeringRemove'},
 
             Slot = 'LCH',
         },
@@ -617,7 +617,7 @@ UnitBlueprint {
             
             Prerequisite = 'EXTorpedoRapidLoader',
 
-            RemoveEnhancements = {'EXTorpedoLauncher','EXTorpedoRapidLoader','EXTorpedoRapidLoaderRemove'},
+            RemoveEnhancements = {'EXTorpedoRapidLoader','EXTorpedoRapidLoaderRemove'},
 
             Slot = 'RCH',
         },
@@ -656,7 +656,7 @@ UnitBlueprint {
             
             Prerequisite = 'EXTorpedoClusterLauncher',
 
-            RemoveEnhancements = {'EXTorpedoLauncher','EXTorpedoRapidLoader','EXTorpedoClusterLauncher','EXTorpedoClusterLauncherRemove'},
+            RemoveEnhancements = {'EXTorpedoClusterLauncher','EXTorpedoClusterLauncherRemove'},
 
             Slot = 'RCH',
         },
@@ -723,7 +723,7 @@ UnitBlueprint {
             
             Prerequisite = 'EXAdvancedShells',
 
-            RemoveEnhancements = {'EXArtilleryMiasma','EXAdvancedShells','EXAdvancedShellsRemove'},
+            RemoveEnhancements = {'EXAdvancedShells','EXAdvancedShellsRemove'},
 
             Slot = 'RCH',
         },
@@ -758,7 +758,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXImprovedReloader',
 
-            RemoveEnhancements = {'EXArtilleryMiasma','EXAdvancedShells','EXImprovedReloader','EXImprovedReloaderRemove'},
+            RemoveEnhancements = {'EXImprovedReloader','EXImprovedReloaderRemove'},
 
             Slot = 'RCH',
         },
@@ -842,7 +842,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXImprovedCoolingSystem',
 
-            RemoveEnhancements = {'EXBeamPhason','EXImprovedCoolingSystem','EXImprovedCoolingSystemRemove'},
+            RemoveEnhancements = {'EXImprovedCoolingSystem','EXImprovedCoolingSystemRemove'},
 
             Slot = 'RCH',
         },
@@ -883,7 +883,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXPowerBooster',
 
-            RemoveEnhancements = {'EXBeamPhason','EXImprovedCoolingSystem','EXPowerBooster','EXPowerBoosterRemove'},
+            RemoveEnhancements = {'EXPowerBooster','EXPowerBoosterRemove'},
 
             Slot = 'RCH',
         },
@@ -920,7 +920,7 @@ UnitBlueprint {
 
             Name = 'Remove Intel Enhancement',
 
-            Prerequisite = 'EXIntelEnhancement',
+            Prerequisite = 'EXIntelEnhancementT2',
 
             RemoveEnhancements = {'EXIntelEnhancementT2','EXIntelEnhancementT2Remove'},
 
@@ -1002,7 +1002,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXIntelRhianneDevice',
 
-            RemoveEnhancements = {'EXIntelRhianneDevice','EXIntelRhianneDeviceRemove','EXIntelEnhancementT3','EXIntelEnhancementT3Remove'},
+            RemoveEnhancements = {'EXIntelRhianneDevice','EXIntelRhianneDeviceRemove'},
 
             Slot = 'Command',
         },
@@ -1084,7 +1084,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXMaelstromFieldExpander',
 
-            RemoveEnhancements = {'EXMaelstromQuantum','EXMaelstromFieldExpander','EXMaelstromFieldExpanderRemove'},
+            RemoveEnhancements = {'EXMaelstromFieldExpander','EXMaelstromFieldExpanderRemove'},
 
             Slot = 'Back',
         },
@@ -1123,7 +1123,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXMaelstromQuantumInstability',
 
-            RemoveEnhancements = {'EXMaelstromQuantum','EXMaelstromFieldExpander','EXMaelstromQuantumInstability','EXMaelstromQuantumInstabilityRemove'},
+            RemoveEnhancements = {'EXMaelstromQuantumInstability','EXMaelstromQuantumInstabilityRemove'},
 
             Slot = 'Back',
         },
@@ -1259,7 +1259,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXActiveSkinShield',
 
-            RemoveEnhancements = {'EXShieldBubble','EXActiveSkinShield','EXActiveSkinShieldRemove'},
+            RemoveEnhancements = {'EXActiveSkinShield','EXActiveSkinShieldRemove'},
 
             Slot = 'Back',
         },
@@ -1312,7 +1312,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXAdvancedSkinShield',
 
-            RemoveEnhancements = {'EXShieldBubble','EXActiveSkinShield','EXAdvancedSkinShield','EXAdvancedSkinShieldRemove'},
+            RemoveEnhancements = {'EXAdvancedSkinShield','EXAdvancedSkinShieldRemove'},
 
             Slot = 'Back',
         },

--- a/gamedata/BlackOps/mods/BlackopsACUs/units/EEL0001/EEL0001_unit.bp
+++ b/gamedata/BlackOps/mods/BlackopsACUs/units/EEL0001/EEL0001_unit.bp
@@ -607,7 +607,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXTorpedoRapidLoader',
 
-            RemoveEnhancements = {'EXTorpedoLauncher','EXTorpedoRapidLoader','EXTorpedoRapidLoaderRemove'},
+            RemoveEnhancements = {'EXTorpedoRapidLoader','EXTorpedoRapidLoaderRemove'},
 
             Slot = 'RCH',
         },
@@ -646,7 +646,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXTorpedoClusterLauncher',
 
-            RemoveEnhancements = {'EXTorpedoLauncher','EXTorpedoRapidLoader','EXTorpedoClusterLauncher','EXTorpedoClusterLauncherRemove'},
+            RemoveEnhancements = {'EXTorpedoClusterLauncher','EXTorpedoClusterLauncherRemove'},
 
             Slot = 'RCH',
         },
@@ -723,7 +723,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXImprovedContainmentBottle',
 
-            RemoveEnhancements = {'EXAntiMatterCannon','EXImprovedContainmentBottle','EXImprovedContainmentBottleRemove'},
+            RemoveEnhancements = {'EXImprovedContainmentBottle','EXImprovedContainmentBottleRemove'},
 
             Slot = 'RCH',
         },
@@ -762,7 +762,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXPowerBooster',
 
-            RemoveEnhancements = {'EXAntiMatterCannon','EXImprovedContainmentBottle','EXPowerBooster','EXPowerBoosterRemove'},
+            RemoveEnhancements = {'EXPowerBooster','EXPowerBoosterRemove'},
 
             Slot = 'RCH',
         },
@@ -838,7 +838,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXImprovedCoolingSystem',
 
-            RemoveEnhancements = {'EXGattlingEnergyCannon','EXImprovedCoolingSystem','EXImprovedCoolingSystemRemove'},
+            RemoveEnhancements = {'EXImprovedCoolingSystem','EXImprovedCoolingSystemRemove'},
 
             Slot = 'RCH',
         },
@@ -877,7 +877,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXEnergyShellHardener',
 
-            RemoveEnhancements = {'EXGattlingEnergyCannon','EXImprovedCoolingSystem','EXEnergyShellHardener','EXEnergyShellHardenerRemove'},
+            RemoveEnhancements = {'EXEnergyShellHardener','EXEnergyShellHardenerRemove'},
 
             Slot = 'RCH',
         },
@@ -914,7 +914,7 @@ UnitBlueprint {
 
             Name = 'Remove Intel Package',
 
-            Prerequisite = 'EXIntelEnhancement',
+            Prerequisite = 'EXIntelEnhancementT2',
 
             RemoveEnhancements = {'EXIntelEnhancementT2','EXIntelEnhancementT2Remove'},
 
@@ -998,7 +998,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXSatelliteSystem',
 
-            RemoveEnhancements = {'EXSatelliteSystem','EXSatelliteSystemRemove','EXIntelEnhancementT3','EXIntelEnhancementT2'},
+            RemoveEnhancements = {'EXSatelliteSystem','EXSatelliteSystemRemove'},
 
             Slot = 'Command',
         },
@@ -1111,7 +1111,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXActiveSkinShield',
 
-            RemoveEnhancements = {'EXShieldBubble','EXActiveSkinShield','EXActiveSkinShieldRemove'},
+            RemoveEnhancements = {'EXActiveSkinShield','EXActiveSkinShieldRemove'},
 
             Slot = 'Back',
         },
@@ -1168,7 +1168,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXAdvancedSkinShield',
 
-            RemoveEnhancements = {'EXShieldBubble','EXActiveSkinShield','EXAdvancedSkinShield','EXAdvancedSkinShieldRemove' },
+            RemoveEnhancements = {'EXAdvancedSkinShield','EXAdvancedSkinShieldRemove' },
 
             Slot = 'Back',
         },
@@ -1220,7 +1220,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXTyphoonBubble',
 
-            RemoveEnhancements = {'EXShieldBubble','EXActiveSkinShield','EXAdvancedSkinShield','EXTyphoonBubble','EXTyphoonBubbleRemove'},
+            RemoveEnhancements = {'EXTyphoonBubble','EXTyphoonBubbleRemove'},
 
             Slot = 'Back',
         },
@@ -1295,7 +1295,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXClusterMisslesPack',
 
-            RemoveEnhancements = {'EXClusterMisslePack','EXClusterMisslesPack','EXClusterMisslesPackRemove'},
+            RemoveEnhancements = {'EXClusterMisslesPack','EXClusterMisslesPackRemove'},
 
             Slot = 'Back',
         },
@@ -1332,7 +1332,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXClusterMissleSalvoPack',
 
-            RemoveEnhancements = {'EXClusterMisslePack','EXClusterMisslesPack','EXClusterMissleSalvoPack','EXClusterMissleSalvoPackRemove'},
+            RemoveEnhancements = {'EXClusterMissleSalvoPack','EXClusterMissleSalvoPackRemove'},
 
             Slot = 'Back',
         },
@@ -1443,7 +1443,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXTacticalNukeSubstitution',
 
-            RemoveEnhancements = {'EXTacticalMisslePack','EXTacticalNukeSubstitution','EXTacticalNukeSubstitutionRemove'},
+            RemoveEnhancements = {'EXTacticalNukeSubstitution','EXTacticalNukeSubstitutionRemove'},
 
             Slot = 'Back',
         },

--- a/gamedata/BlackOps/mods/BlackopsACUs/units/ERL0001/ERL0001_unit.bp
+++ b/gamedata/BlackOps/mods/BlackopsACUs/units/ERL0001/ERL0001_unit.bp
@@ -378,7 +378,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXExperimentalEngineering',
 
-            RemoveEnhancements = {'EXExperimentalEngineering','EXExperimentalEngineeringRemove' },
+            RemoveEnhancements = {'EXExperimentalEngineering','EXExperimentalEngineeringRemove'},
 
             Slot = 'LCH',
         },
@@ -417,7 +417,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXCombatEngineering',
 
-            RemoveEnhancements = {'EXCombatEngineering','EXCombatEngineeringRemove' },
+            RemoveEnhancements = {'EXCombatEngineering','EXCombatEngineeringRemove'},
 
             Slot = 'LCH',
         },
@@ -458,7 +458,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXAssaultEngineering',
 
-            RemoveEnhancements = {'EXAssaultEngineering','EXAssaultEngineeringRemove' },
+            RemoveEnhancements = {'EXAssaultEngineering','EXAssaultEngineeringRemove'},
 
             Slot = 'LCH',
         },
@@ -499,7 +499,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXApocalypticEngineering',
 
-            RemoveEnhancements = {'EXApocalypticEngineering','EXApocalypticEngineeringRemove' },
+            RemoveEnhancements = {'EXApocalypticEngineering','EXApocalypticEngineeringRemove'},
 
             Slot = 'LCH',
         },
@@ -533,7 +533,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXRipperBooster',
 
-            RemoveEnhancements = {'EXRipperBooster','EXRipperBoosterRemove' },
+            RemoveEnhancements = {'EXRipperBooster','EXRipperBoosterRemove'},
 
             Slot = 'RCH',
         },
@@ -609,7 +609,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXTorpedoRapidLoader',
 
-            RemoveEnhancements = {'EXTorpedoLauncher','EXTorpedoRapidLoader','EXTorpedoRapidLoaderRemove'},
+            RemoveEnhancements = {'EXTorpedoRapidLoader','EXTorpedoRapidLoaderRemove'},
 
             Slot = 'RCH',
         },
@@ -648,7 +648,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXTorpedoClusterLauncher',
 
-            RemoveEnhancements = {'EXTorpedoLauncher','EXTorpedoRapidLoader','EXTorpedoClusterLauncher','EXTorpedoClusterLauncherRemove'},
+            RemoveEnhancements = {'EXTorpedoClusterLauncher','EXTorpedoClusterLauncherRemove'},
 
             Slot = 'RCH',
         },
@@ -724,7 +724,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXImprovedCapacitors',
 
-            RemoveEnhancements = {'EXEMPArray','EXImprovedCapacitors','EXImprovedCapacitorsRemove'},
+            RemoveEnhancements = {'EXImprovedCapacitors','EXImprovedCapacitorsRemove'},
 
             Slot = 'RCH',
         },
@@ -763,7 +763,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXPowerBooster',
 
-            RemoveEnhancements = {'EXEMPArray','EXImprovedCapacitors','EXPowerBooster','EXPowerBoosterRemove'},
+            RemoveEnhancements = {'EXPowerBooster','EXPowerBoosterRemove'},
 
             Slot = 'RCH',
         },
@@ -847,7 +847,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXImprovedCoolingSystem',
 
-            RemoveEnhancements = {'EXMasor','EXImprovedCoolingSystem','EXImprovedCoolingSystemRemove'},
+            RemoveEnhancements = {'EXImprovedCoolingSystem','EXImprovedCoolingSystemRemove'},
 
             Slot = 'RCH',
         },
@@ -890,7 +890,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXAdvancedEmitterArray',
 
-            RemoveEnhancements = {'EXMasor','EXImprovedCoolingSystem','EXAdvancedEmitterArray','EXAdvancedEmitterArrayRemove'},
+            RemoveEnhancements = {'EXAdvancedEmitterArray','EXAdvancedEmitterArrayRemove'},
 
             Slot = 'RCH',
         },
@@ -923,7 +923,7 @@ UnitBlueprint {
 
             Name = 'Remove Intel Package',
 
-            Prerequisite = 'EXIntelEnhancement',
+            Prerequisite = 'EXIntelEnhancementT2',
 
             RemoveEnhancements = {'EXIntelEnhancementT2','EXIntelEnhancementT2Remove'},
 
@@ -999,7 +999,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXPerimeterOptics',
 
-            RemoveEnhancements = {'EXIntelEnhancementT2','EXIntelEnhancementT3','EXPerimeterOptics','EXPerimeterOpticsRemove'},
+            RemoveEnhancements = {'EXPerimeterOptics','EXPerimeterOpticsRemove'},
 
             Slot = 'Command',
         },
@@ -1112,7 +1112,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXArmorPlating',
 
-            RemoveEnhancements = {'EXArmorPlating','EXArmorPlatingRemove','EXAgilityPackage','EXAgilityPackageRemove'},
+            RemoveEnhancements = {'EXArmorPlating','EXArmorPlatingRemove'},
 
             Slot = 'Back',
         },
@@ -1231,7 +1231,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXCloakingSubsystems',
 
-            RemoveEnhancements = {'EXCloakingSubsystems','EXCloakingSubsystemsRemove','EXStealthField',},
+            RemoveEnhancements = {'EXCloakingSubsystems','EXCloakingSubsystemsRemove'},
 
             Slot = 'Back',
         },
@@ -1272,7 +1272,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXDeviatorField',
 
-            RemoveEnhancements = {'EXStealthField','EXcloakingSubsystems','EXDeviatorField','EXDeviatorFieldRemove'},
+            RemoveEnhancements = {'EXDeviatorField','EXDeviatorFieldRemove'},
 
             Slot = 'Back',
         },

--- a/gamedata/BlackOps/mods/BlackopsACUs/units/ESL0001/ESL0001_unit.bp
+++ b/gamedata/BlackOps/mods/BlackopsACUs/units/ESL0001/ESL0001_unit.bp
@@ -351,10 +351,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXAdvancedEngineering',
 
-            RemoveEnhancements = {
-                'EXAdvancedEngineering',
-                'EXAdvancedEngineeringRemove',
-            },
+            RemoveEnhancements = {'EXAdvancedEngineering','EXAdvancedEngineeringRemove'},
 
             Slot = 'LCH',
         },
@@ -625,7 +622,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXTorpedoRapidLoader',
 
-            RemoveEnhancements = {'EXTorpedoLauncher','EXTorpedoRapidLoader','EXTorpedoRapidLoaderRemove'},
+            RemoveEnhancements = {'EXTorpedoRapidLoader','EXTorpedoRapidLoaderRemove'},
 
             Slot = 'RCH',
         },
@@ -664,7 +661,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXTorpedoClusterLauncher',
 
-            RemoveEnhancements = {'EXTorpedoLauncher','EXTorpedoRapidLoader','EXTorpedoClusterLauncher','EXTorpedoClusterLauncherRemove'},
+            RemoveEnhancements = {'EXTorpedoClusterLauncher','EXTorpedoClusterLauncherRemove'},
 
             Slot = 'RCH',
         },
@@ -701,9 +698,9 @@ UnitBlueprint {
 
             Name = 'Remove Storm Cannon',
 
-            Prerequisite = 'EXCannonBigBall',
+            Prerequisite = 'EXStormCannon',
 
-            RemoveEnhancements = { 'EXCannonBigBall','EXCannonBigBallRemove' },
+            RemoveEnhancements = {'EXStormCannon','EXStormCannonRemove'},
             Slot = 'RCH',
         },
 
@@ -742,7 +739,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXStormCannonII',
 
-            RemoveEnhancements = {'EXStormCannon','EXStormCannonII','EXStormCannonIIRemove'},
+            RemoveEnhancements = {'EXStormCannonII','EXStormCannonIIRemove'},
             Slot = 'RCH',
         },
 
@@ -782,7 +779,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXStormCannonIII',
 
-            RemoveEnhancements = {'EXStormCannon','EXStormCannonII','EXStormCannonIII','EXStormCannonIIIRemove'},
+            RemoveEnhancements = {'EXStormCannonIII','EXStormCannonIIIRemove'},
             Slot = 'RCH',
         },
 
@@ -856,7 +853,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXRapidCannonII',
 
-            RemoveEnhancements = {'EXRapidCannon','EXRapidCannonII','EXRapidCannonIIRemove'},
+            RemoveEnhancements = {'EXRapidCannonII','EXRapidCannonIIRemove'},
             Slot = 'RCH',
         },
 
@@ -894,7 +891,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXRapidCannonIII',
 
-            RemoveEnhancements = {'EXRapidCannon','EXRapidCannonII','EXRapidCannonIII','EXRapidCannonIIIRemove'},
+            RemoveEnhancements = {'EXRapidCannonIII','EXRapidCannonIIIRemove'},
             Slot = 'RCH',
         },
 		
@@ -930,7 +927,7 @@ UnitBlueprint {
 
             Name = 'Remove Intel Package',
 
-            Prerequisite = 'EXIntelEnhancement',
+            Prerequisite = 'EXIntelEnhancementT2',
 
             RemoveEnhancements = {'EXIntelEnhancementT2','EXIntelEnhancementT2Remove'},
 
@@ -1080,7 +1077,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXL2Lambda',
 
-            RemoveEnhancements = {'EXL1Lambda','EXL2Lambda','EXL2LambdaRemove'},
+            RemoveEnhancements = {'EXL2Lambda','EXL2LambdaRemove'},
 
             Slot = 'Back',
         },
@@ -1199,7 +1196,7 @@ UnitBlueprint {
 
             Prerequisite = 'EXCloakingSubsystems',
 
-            RemoveEnhancements = {'EXBasicDefense','EXStealthField','EXCloakingSubsystems','EXCloakingSubsystemsRemove'},
+            RemoveEnhancements = {'EXCloakingSubsystems','EXCloakingSubsystemsRemove'},
 
             Slot = 'Back',
         },


### PR DESCRIPTION
* Corrected prerequisite for removal of Intel Enhancement (T2) for all 4 ACUs
* Replaced EXCannonBigBall with correct enhancement name EXStormCannon for Sera ACU
* Cleanup of extraneous names in removal enhancements