### PR TITLE
Stargate Aquatic Build Update

### DIFF
--- a/gamedata/BrewLAN_LOUD/mods/BrewLAN_LOUD/units/SSB5401/SSB5401_script.lua
+++ b/gamedata/BrewLAN_LOUD/mods/BrewLAN_LOUD/units/SSB5401/SSB5401_script.lua
@@ -7,6 +7,18 @@ local StargateDialing = import(import( '/lua/game.lua' ).BrewLANLOUDPath() .. '/
 
 TeleportUnit = StargateDialing(TeleportUnit) 
 
-SSB5401 = Class(TeleportUnit) {}
+SSB5401 = Class(TeleportUnit) {
+
+    OnCreate = function(self)
+
+        if self:GetCurrentLayer() ~= 'Land' then
+            self:HideBone('XSB0304', false)
+        end
+
+        TeleportUnit.OnCreate(self)
+
+    end,
+
+}
 
 TypeClass = SSB5401

--- a/gamedata/BrewLAN_LOUD/mods/BrewLAN_LOUD/units/SSB5401/SSB5401_unit.bp
+++ b/gamedata/BrewLAN_LOUD/mods/BrewLAN_LOUD/units/SSB5401/SSB5401_unit.bp
@@ -111,9 +111,12 @@ UnitBlueprint {
         },
     },
 
-    Description = '<LOC ssb5401_desc>Experimental Quantum Gateway',
+    Description = '<LOC ssb5401_desc>Experimental Teleport Gateway',
 
     Display = {
+        Abilities = {
+            '<LOC ability_aquatic>Aquatic',
+        },
         BlinkingLights = {
             { BLBone = 'Light04', BLOffsetZ = 0.05, BLScale = 1 },
             { BLBone = 'Light05', BLOffsetZ = 0.05, BLScale = 1 },
@@ -194,7 +197,7 @@ UnitBlueprint {
     General = {
         ConstructionBar = true,
         FactionName = 'Seraphim',
-        Icon = 'land',
+        Icon = 'amph',
 
         OrderOverrides = {
             RULEUTC_GenericToggle = { bitmapId = 'stop', helpText = 'stargate_stop' },
@@ -212,10 +215,6 @@ UnitBlueprint {
         VisionRadius = 20,
     },
 
-    Interface = {
-        HelpText = '<LOC ssb5401_desc>Experimental Teleport Gateway',
-    },
-
     LifeBarHeight = 0.075,
     LifeBarOffset = 2.65,
     LifeBarSize = 5.5,
@@ -224,6 +223,7 @@ UnitBlueprint {
         BankingSlope = 0,
         BuildOnLayerCaps = {
             LAYER_Land = true,
+            LAYER_Sub = true,
         },
         DragCoefficient = 0.2,
 


### PR DESCRIPTION
* Added layer Sub to Sera Chappa'ai T4 Experimental Teleport Gateway to make it possible to build in water for naval units to use.
* Added code to hide the platform when built in water (thanks to Balthazar).