### PR TITLE
Beam effect partial rework with show/hide

### DIFF
--- a/gamedata/lua/lua/EffectUtilities.lua
+++ b/gamedata/lua/lua/EffectUtilities.lua
@@ -1565,7 +1565,8 @@ function CreateAdjacencyBeams( unit, adjacentUnit )
 	local LOUDATTACHEMITTER = CreateAttachedEmitter
     local TrashAdd = TrashAdd
 
-	local info = { Unit = adjacentUnit.EntityID, Trash = TrashBag(), }
+	local Trash = TrashBag()
+	-- local info = { Unit = adjacentUnit.EntityID, Trash = TrashBag(), }
     
     local army = unit.Army
     local faction = __blueprints[unit.BlueprintID].General.FactionName
@@ -1591,11 +1592,12 @@ function CreateAdjacencyBeams( unit, adjacentUnit )
     
         local beam = LOUDATTACHBEAMENTITY( unit, -1, adjacentUnit, -1, army, beamEffect )
         
-        TrashAdd( info.Trash, beam )
+        TrashAdd( Trash, beam )
         TrashAdd( unit.Trash, beam )
     end
 
-	LOUDINSERT( unit.AdjacencyBeamsBag, info)
+	return Trash
+	-- LOUDINSERT( unit.AdjacencyBeamsBag, info)
 
 end
 

--- a/gamedata/lua/lua/defaultunits.lua
+++ b/gamedata/lua/lua/defaultunits.lua
@@ -1036,9 +1036,51 @@ StructureUnit = Class(Unit) {
 			
 		end
 
-		CreateAdjacencyBeams( self, adjacentUnit )
-
+		table.insert(self.AdjacencyBeamsBag, {
+	        Unit = adjacentUnit,
+	        -- Trash = CreateAdjacencyBeams( self, adjacentUnit ), --TODO check effect is active
+	    }
+		
     end,
+
+	ShowAdjacentEffects = function(self, adjacentUnit)
+			
+		if not self.AdjacencyBeamsBag then
+			return
+		end
+			
+		for k, v in self.AdjacencyBeamsBag do
+
+			if v.Unit == adjacentUnit.EntityID then
+				if not v.Trash then
+					v.Trash = CreateAdjacencyBeams( self, adjacentUnit )
+				end
+				return
+			end
+			
+		end
+			
+	end,
+		
+	HideAdjacentEffects = function(self, adjacentUnit)
+			
+		if not self.AdjacencyBeamsBag then
+			return
+		end
+			
+		for k, v in self.AdjacencyBeamsBag do
+
+			if v.Unit == adjacentUnit.EntityID then
+				if v.Trash then
+					v.Trash:Destroy()
+					v.Trash = nil
+				end
+				return
+			end
+			
+		end
+			
+	end,
 
     DestroyAdjacentEffects = function(self, adjacentUnit)
 


### PR DESCRIPTION
This changes `CreateAdjacencyBeams` to return the Trash rather than handle the whole data table, and have the defaultunit Adjacency methods handle the data table for better control of the effects, and adds show/hide effects methods, which it currently doesn't use.