### PR TITLE
Multi-role Icon changed to Fighter, DEA0202 (UEF 2 fighter)

### DIFF
--- a/gamedata/units/units/DEA0202/DEA0202_unit.bp
+++ b/gamedata/units/units/DEA0202/DEA0202_unit.bp
@@ -180,7 +180,7 @@ UnitBlueprint {
     SizeY = 0.4,
     SizeZ = 1,
 	
-    StrategicIconName = 'icon_fighter2_directfire',
+    StrategicIconName = 'icon_fighter2_antiair',
     StrategicIconSortPriority = 55,
 	
     Transport = {


### PR DESCRIPTION
A unit that was originally a multi-role fighter/bomber isnt a multi-role fighter/bomber in LOUD. and is just a Fighter now.
 
I changed the Icon to reflect this, as it still had the original Multi-role icon.